### PR TITLE
Added errorMinimizers with ICP's covariance estimation

### DIFF
--- a/pointmatcher/Bibliography.cpp
+++ b/pointmatcher/Bibliography.cpp
@@ -109,6 +109,17 @@ namespace PointMatcherSupport
 				( "doi", "10.1109/34.121791" )
 				( "fulltext", "http://ieeexplore.ieee.org/xpls/abs_all.jsp?arnumber=121791")
 			))
+			( "Censi2007ICPCovariance", makeMap(map_list_of
+				( "type", "inproceedings" )
+				( "title", "An Accurate Closed-Form Estimate of {ICP}'s Covariance" )
+				( "author", "Censi, A." )
+				( "booktitle", "Proceedings of the {IEEE} International Conference on Robotics and Automation ({ICRA})" )
+				( "year", "2007" )
+				( "pages", "3167--3172" )
+				( "publisher", "IEEE Press" )
+				( "doi", "10.1109/ROBOT.2007.363961" )
+				( "fulltext", "http://purl.org/censi/research/2007-icra-icpcov.pdf")
+			))
 			( "Chen1991Point2Plane", makeMap(map_list_of
 				( "type", "inproceedings" )
 				( "title", "Object modeling by registration of multiple range images" )

--- a/pointmatcher/ErrorMinimizer.cpp
+++ b/pointmatcher/ErrorMinimizer.cpp
@@ -90,6 +90,14 @@ T PointMatcher<T>::ErrorMinimizer::getOverlap() const
 	return weightedPointUsedRatio;
 }
 
+//! If not redefined by child class, return zero matrix
+template<typename T>
+typename PointMatcher<T>::Matrix PointMatcher<T>::ErrorMinimizer::getCovariance() const
+{
+  LOG_INFO_STREAM("ErrorMinimizer - warning, no specific method to compute covariance was provided for the ErrorMinimizer used.");
+  return Matrix::Zero(6,6);
+}
+
 //! Helper funtion doing the cross product in 3D and a pseudo cross product in 2D
 template<typename T>
 typename PointMatcher<T>::Matrix PointMatcher<T>::ErrorMinimizer::crossProduct(const Matrix& A, const Matrix& B)

--- a/pointmatcher/ErrorMinimizersImpl.cpp
+++ b/pointmatcher/ErrorMinimizersImpl.cpp
@@ -291,3 +291,443 @@ T ErrorMinimizersImpl<T>::PointToPlaneErrorMinimizer::getOverlap() const
 
 template struct ErrorMinimizersImpl<float>::PointToPlaneErrorMinimizer;
 template struct ErrorMinimizersImpl<double>::PointToPlaneErrorMinimizer;
+
+
+
+// Point To POINT WITH COV ErrorMinimizer
+template<typename T>
+ErrorMinimizersImpl<T>::PointToPointWithCovErrorMinimizer::PointToPointWithCovErrorMinimizer(const Parameters& params):
+	ErrorMinimizer("PointToPointWithCovErrorMinimizer", PointToPointWithCovErrorMinimizer::availableParameters(), params),
+	sensorStdDev(Parametrizable::get<T>("sensorStdDev"))
+{
+}
+
+template<typename T>
+typename PointMatcher<T>::TransformationParameters ErrorMinimizersImpl<T>::PointToPointWithCovErrorMinimizer::compute(
+	const DataPoints& filteredReading,
+	const DataPoints& filteredReference,
+	const OutlierWeights& outlierWeights,
+	const Matches& matches)
+{
+	typedef typename Matches::Ids Ids;
+	
+	assert(matches.ids.rows() > 0);
+
+	typename ErrorMinimizer::ErrorElements& mPts = this->getMatchedPoints(filteredReading, filteredReference, matches, outlierWeights);
+	
+	// now minimize on kept points
+	const int dimCount(mPts.reading.features.rows());
+	const int ptsCount(mPts.reading.features.cols()); //But point cloud have now the same number of (matched) point
+
+	// Compute the mean of each point cloud
+	const Vector meanReading = mPts.reading.features.rowwise().sum() / ptsCount;
+	const Vector meanReference = mPts.reference.features.rowwise().sum() / ptsCount;
+	
+	// Remove the mean from the point clouds
+	mPts.reading.features.colwise() -= meanReading;
+	mPts.reference.features.colwise() -= meanReference;
+
+	// Singular Value Decomposition
+	const Matrix m(mPts.reference.features.topRows(dimCount-1) * mPts.reading.features.topRows(dimCount-1).transpose());
+	const JacobiSVD<Matrix> svd(m, ComputeThinU | ComputeThinV);
+	const Matrix rotMatrix(svd.matrixU() * svd.matrixV().transpose());
+	const Vector trVector(meanReference.head(dimCount-1)- rotMatrix * meanReading.head(dimCount-1));
+	
+	Matrix result(Matrix::Identity(dimCount, dimCount));
+	result.corner(TopLeft, dimCount-1, dimCount-1) = rotMatrix;
+	result.corner(TopRight, dimCount-1, 1) = trVector;
+
+	this->covMatrix = this->estimateCovariance(filteredReading, filteredReference, matches, outlierWeights, result);
+
+	return result;
+}
+
+template<typename T>
+typename ErrorMinimizersImpl<T>::Matrix
+ErrorMinimizersImpl<T>::PointToPointWithCovErrorMinimizer::estimateCovariance(const DataPoints& reading, const DataPoints& reference, const Matches& matches, const OutlierWeights& outlierWeights, const TransformationParameters& transformation)
+{
+	int max_nbr_point = outlierWeights.cols();
+
+	Matrix covariance(Matrix::Zero(6,6));
+	Matrix J_hessian(Matrix::Zero(6,6));
+	Matrix d2J_dReadingdX(Matrix::Zero(6, max_nbr_point));
+	Matrix d2J_dReferencedX(Matrix::Zero(6, max_nbr_point));
+
+	Vector reading_point(Vector::Zero(3));
+	Vector reference_point(Vector::Zero(3));
+	Vector normal(3);
+	Vector reading_direction(Vector::Zero(3));
+	Vector reference_direction(Vector::Zero(3));
+
+	normal << 1.0, 1.0, 1.0;    // Used for point-to-point computation
+
+	T beta = -asin(transformation(2,0));
+	T alpha = atan2(transformation(2,1), transformation(2,2));
+	T gamma = atan2(transformation(1,0)/cos(beta), transformation(0,0)/cos(beta));
+	T t_x = transformation(0,3);
+	T t_y = transformation(1,3);
+	T t_z = transformation(2,3);
+
+	Vector tmp_vector_6(Vector::Zero(6));
+
+	int valid_points_count = 0;
+
+	for(int i = 0; i < max_nbr_point; ++i)
+	{
+		if (outlierWeights(0,i) > 0.0)
+		{
+			reading_point = reading.features.block(0,i,3,1);
+			int reference_idx = matches.ids(0,i);
+			reference_point = reference.features.block(0,reference_idx,3,1);
+
+			T reading_range = reading_point.norm();
+			reading_direction = reading_point / reading_range;
+			T reference_range = reference_point.norm();
+			reference_direction = reference_point / reference_range;
+
+			T n_alpha = normal(2)*reading_direction(1) - normal(1)*reading_direction(2);
+			T n_beta = normal(0)*reading_direction(2) - normal(2)*reading_direction(0);
+			T n_gamma = normal(1)*reading_direction(0) - normal(0)*reading_direction(1);
+
+			T E = normal(0)*(reading_point(0) - gamma*reading_point(1) + beta*reading_point(2) + t_x - reference_point(0));
+			E +=  normal(1)*(gamma*reading_point(0) + reading_point(1) - alpha*reading_point(2) + t_y - reference_point(1));
+			E +=  normal(2)*(-beta*reading_point(0) + alpha*reading_point(1) + reading_point(2) + t_z - reference_point(2));
+
+			T N_reading = normal(0)*(reading_direction(0) - gamma*reading_direction(1) + beta*reading_direction(2));
+			N_reading +=  normal(1)*(gamma*reading_direction(0) + reading_direction(1) - alpha*reading_direction(2));
+			N_reading +=  normal(2)*(-beta*reading_direction(0) + alpha*reading_direction(1) + reading_direction(2));
+
+			T N_reference = -(normal(0)*reference_direction(0) + normal(1)*reference_direction(1) + normal(2)*reference_direction(2));
+
+			// update the hessian and d2J/dzdx
+			tmp_vector_6 << normal(0), normal(1), normal(2), reading_range * n_alpha, reading_range * n_beta, reading_range * n_gamma;
+
+			J_hessian += tmp_vector_6 * tmp_vector_6.transpose();
+
+			tmp_vector_6 << normal(0) * N_reading, normal(1) * N_reading, normal(2) * N_reading, n_alpha * (E + reading_range * N_reading), n_beta * (E + reading_range * N_reading), n_gamma * (E + reading_range * N_reading);
+
+			d2J_dReadingdX.block(0,valid_points_count,6,1) = tmp_vector_6;
+
+			tmp_vector_6 << normal(0) * N_reference, normal(1) * N_reference, normal(2) * N_reference, reference_range * n_alpha * N_reference, reference_range * n_beta * N_reference, reference_range * n_gamma * N_reference;
+
+			d2J_dReferencedX.block(0,valid_points_count,6,1) = tmp_vector_6;
+
+			valid_points_count++;
+		} // if (outlierWeights(0,i) > 0.0)
+	}
+
+	Matrix d2J_dZdX(Matrix::Zero(6, 2 * valid_points_count));
+	d2J_dZdX.block(0,0,6,valid_points_count) = d2J_dReadingdX.block(0,0,6,valid_points_count);
+	d2J_dZdX.block(0,valid_points_count,6,valid_points_count) = d2J_dReferencedX.block(0,0,6,valid_points_count);
+
+	Matrix inv_J_hessian = J_hessian.inverse();
+
+	covariance = d2J_dZdX * d2J_dZdX.transpose();
+	covariance = inv_J_hessian * covariance * inv_J_hessian;
+
+	return (sensorStdDev * sensorStdDev) * covariance;
+}
+
+template<typename T>
+T ErrorMinimizersImpl<T>::PointToPointWithCovErrorMinimizer::getOverlap() const
+{
+	const int nbPoints = this->lastErrorElements.reading.features.cols();
+	if(nbPoints == 0)
+	{
+		throw std::runtime_error("Error, last error element empty. Error minimizer needs to be called at least once before using this method.");
+	}
+
+	if (!this->lastErrorElements.reading.descriptorExists("simpleSensorNoise"))
+	{
+		LOG_INFO_STREAM("PointToPointErrorMinimizer - warning, no sensor noise found. Using best estimate given outlier rejection instead.");
+		return this->weightedPointUsedRatio;
+	}
+
+	const BOOST_AUTO(noises, this->lastErrorElements.reading.getDescriptorViewByName("simpleSensorNoise"));
+	int count = 0;
+	for(int i=0; i < nbPoints; i++)
+	{
+		const T dist = (this->lastErrorElements.reading.features.col(i) - this->lastErrorElements.reference.features.col(i)).norm();
+		if(dist < noises(0,i))
+			count++;
+	}
+
+	return count/nbPoints;
+}
+
+template<typename T>
+typename ErrorMinimizersImpl<T>::Matrix ErrorMinimizersImpl<T>::PointToPointWithCovErrorMinimizer::getCovariance() const
+{
+  return covMatrix;
+}
+
+template struct ErrorMinimizersImpl<float>::PointToPointWithCovErrorMinimizer;
+template struct ErrorMinimizersImpl<double>::PointToPointWithCovErrorMinimizer;
+
+
+// Point To PLANE WITH COV ErrorMinimizer
+template<typename T>
+ErrorMinimizersImpl<T>::PointToPlaneWithCovErrorMinimizer::PointToPlaneWithCovErrorMinimizer(const Parameters& params):
+	ErrorMinimizer("PointToPlaneWithCovErrorMinimizer", PointToPlaneErrorMinimizer::availableParameters(), params),
+	force2D(Parametrizable::get<T>("force2D")),
+	sensorStdDev(Parametrizable::get<T>("sensorStdDev"))
+{
+}
+
+
+template<typename T>
+typename PointMatcher<T>::TransformationParameters ErrorMinimizersImpl<T>::PointToPlaneWithCovErrorMinimizer::compute(
+	const DataPoints& filteredReading,
+	const DataPoints& filteredReference,
+	const OutlierWeights& outlierWeights,
+	const Matches& matches)
+{
+	typedef typename PointMatcher<T>::ConvergenceError ConvergenceError;
+	typedef typename Matches::Ids Ids;
+
+	assert(matches.ids.rows() > 0);
+
+	// Fetch paired points
+	typename ErrorMinimizer::ErrorElements& mPts = this->getMatchedPoints(filteredReading, filteredReference, matches, outlierWeights);
+
+	const int dim = mPts.reading.features.rows();
+	const int nbPts = mPts.reading.features.cols();
+
+	// Adjust if the user forces 2D minimization on XY-plane
+	int forcedDim = dim - 1;
+	if(force2D && dim == 4)
+	{
+		mPts.reading.features.conservativeResize(3, Eigen::NoChange);
+		mPts.reading.features.row(2) = Matrix::Ones(1, nbPts);
+		mPts.reference.features.conservativeResize(3, Eigen::NoChange);
+		mPts.reference.features.row(2) = Matrix::Ones(1, nbPts);
+		forcedDim = dim - 2;
+	}
+
+	// Fetch normal vectors of the reference point cloud (with adjustment if needed)
+	const BOOST_AUTO(normalRef, mPts.reference.getDescriptorViewByName("normals").topRows(forcedDim));
+
+	// Note: Normal vector must be precalculated to use this error. Use appropriate input filter.
+	assert(normalRef.rows() > 0);
+
+	// Compute cross product of cross = cross(reading X normalRef)
+	const Matrix cross = this->crossProduct(mPts.reading.features, normalRef);
+
+	// wF = [weights*cross, normals]
+	// F  = [cross, normals]
+	Matrix wF(normalRef.rows()+ cross.rows(), normalRef.cols());
+	Matrix F(normalRef.rows()+ cross.rows(), normalRef.cols());
+	
+	for(int i=0; i < cross.rows(); i++)
+	{
+		wF.row(i) = mPts.weights.cwise() * cross.row(i);
+		F.row(i) = cross.row(i);
+	}
+	for(int i=0; i < normalRef.rows(); i++)
+	{
+		wF.row(i + cross.rows()) = normalRef.row(i);
+		F.row(i + cross.rows()) = normalRef.row(i);
+	}
+
+	// Unadjust covariance A = wF * F'
+	const Matrix A = wF * F.transpose();
+	if (A.fullPivHouseholderQr().rank() != A.rows())
+	{
+		// TODO: handle that properly
+		//throw ConvergenceError("encountered singular while minimizing point to plane distance");
+	}
+
+	const Matrix deltas = mPts.reading.features - mPts.reference.features;
+
+	// dot product of dot = dot(deltas, normals)
+	Matrix dotProd = Matrix::Zero(1, normalRef.cols());
+	
+	for(int i=0; i<normalRef.rows(); i++)
+	{
+		dotProd += (deltas.row(i).cwise() * normalRef.row(i));
+	}
+
+	// b = -(wF' * dot)
+	const Vector b = -(wF * dotProd.transpose());
+
+	// Cholesky decomposition
+	Vector x(A.rows());
+	A.llt().solve(b, &x);
+	
+	// Transform parameters to matrix
+	Matrix mOut;
+	if(dim == 4 && !force2D)
+	{
+		Eigen::Transform<T, 3, Eigen::Affine> transform;
+		// Rotation in Eular angles follow roll-pitch-yaw (1-2-3) rule
+		transform = Eigen::AngleAxis<T>(x(0), Eigen::Matrix<T,1,3>::UnitX())
+				* Eigen::AngleAxis<T>(x(1), Eigen::Matrix<T,1,3>::UnitY())
+				* Eigen::AngleAxis<T>(x(2), Eigen::Matrix<T,1,3>::UnitZ());
+		// Reverse roll-pitch-yaw conversion, very useful piece of knowledge, keep it with you all time!
+		/*const T pitch = -asin(transform(2,0));
+		const T roll = atan2(transform(2,1), transform(2,2));
+		const T yaw = atan2(transform(1,0) / cos(pitch), transform(0,0) / cos(pitch));
+		std::cerr << "d angles" << x(0) - roll << ", " << x(1) - pitch << "," << x(2) - yaw << std::endl;*/
+		transform.translation() = x.segment(3, 3);
+		mOut = transform.matrix();
+	}
+	else
+	{
+		Eigen::Transform<T, 2, Eigen::Affine> transform;
+		transform = Eigen::Rotation2D<T> (x(0));
+		transform.translation() = x.segment(1, 2);
+
+		if(force2D)
+		{
+			mOut = Matrix::Identity(dim, dim);
+			mOut.corner(TopLeft, 2, 2) = transform.matrix().corner(TopLeft, 2, 2);
+			mOut.corner(TopRight, 2, 1) = transform.matrix().corner(TopRight, 2, 1);
+		}
+		else
+		{
+			mOut = transform.matrix();
+		}
+	}
+
+	this->covMatrix = this->estimateCovariance(filteredReading, filteredReference, matches, outlierWeights, mOut);
+
+	return mOut; 
+}
+
+template<typename T>
+typename ErrorMinimizersImpl<T>::Matrix
+ErrorMinimizersImpl<T>::PointToPlaneWithCovErrorMinimizer::estimateCovariance(const DataPoints& reading, const DataPoints& reference, const Matches& matches, const OutlierWeights& outlierWeights, const TransformationParameters& transformation)
+{
+	int max_nbr_point = outlierWeights.cols();
+
+	Matrix covariance(Matrix::Zero(6,6));
+	Matrix J_hessian(Matrix::Zero(6,6));
+	Matrix d2J_dReadingdX(Matrix::Zero(6, max_nbr_point));
+	Matrix d2J_dReferencedX(Matrix::Zero(6, max_nbr_point));
+
+	Vector reading_point(Vector::Zero(3));
+	Vector reference_point(Vector::Zero(3));
+	Vector normal(3);
+	Vector reading_direction(Vector::Zero(3));
+	Vector reference_direction(Vector::Zero(3));
+
+	Matrix normals = reference.getDescriptorViewByName("normals");
+
+	if (normals.rows() < 3)    // Make sure there are normals in DataPoints
+		return Matrix::Zero(6,6);
+
+	T beta = -asin(transformation(2,0));
+	T alpha = atan2(transformation(2,1), transformation(2,2));
+	T gamma = atan2(transformation(1,0)/cos(beta), transformation(0,0)/cos(beta));
+	T t_x = transformation(0,3);
+	T t_y = transformation(1,3);
+	T t_z = transformation(2,3);
+
+	Vector tmp_vector_6(Vector::Zero(6));
+
+	int valid_points_count = 0;
+
+	for(int i = 0; i < max_nbr_point; ++i)
+	{
+		if (outlierWeights(0,i) > 0.0)
+		{
+			reading_point = reading.features.block(0,i,3,1);
+			int reference_idx = matches.ids(0,i);
+			reference_point = reference.features.block(0,reference_idx,3,1);
+
+			normal = normals.block(0,reference_idx,3,1);
+
+			T reading_range = reading_point.norm();
+			reading_direction = reading_point / reading_range;
+			T reference_range = reference_point.norm();
+			reference_direction = reference_point / reference_range;
+
+			T n_alpha = normal(2)*reading_direction(1) - normal(1)*reading_direction(2);
+			T n_beta = normal(0)*reading_direction(2) - normal(2)*reading_direction(0);
+			T n_gamma = normal(1)*reading_direction(0) - normal(0)*reading_direction(1);
+
+			T E = normal(0)*(reading_point(0) - gamma*reading_point(1) + beta*reading_point(2) + t_x - reference_point(0));
+			E +=  normal(1)*(gamma*reading_point(0) + reading_point(1) - alpha*reading_point(2) + t_y - reference_point(1));
+			E +=  normal(2)*(-beta*reading_point(0) + alpha*reading_point(1) + reading_point(2) + t_z - reference_point(2));
+
+			T N_reading = normal(0)*(reading_direction(0) - gamma*reading_direction(1) + beta*reading_direction(2));
+			N_reading +=  normal(1)*(gamma*reading_direction(0) + reading_direction(1) - alpha*reading_direction(2));
+			N_reading +=  normal(2)*(-beta*reading_direction(0) + alpha*reading_direction(1) + reading_direction(2));
+
+			T N_reference = -(normal(0)*reference_direction(0) + normal(1)*reference_direction(1) + normal(2)*reference_direction(2));
+
+			// update the hessian and d2J/dzdx
+			tmp_vector_6 << normal(0), normal(1), normal(2), reading_range * n_alpha, reading_range * n_beta, reading_range * n_gamma;
+
+			J_hessian += tmp_vector_6 * tmp_vector_6.transpose();
+
+			tmp_vector_6 << normal(0) * N_reading, normal(1) * N_reading, normal(2) * N_reading, n_alpha * (E + reading_range * N_reading), n_beta * (E + reading_range * N_reading), n_gamma * (E + reading_range * N_reading);
+
+			d2J_dReadingdX.block(0,valid_points_count,6,1) = tmp_vector_6;
+
+			tmp_vector_6 << normal(0) * N_reference, normal(1) * N_reference, normal(2) * N_reference, reference_range * n_alpha * N_reference, reference_range * n_beta * N_reference, reference_range * n_gamma * N_reference;
+
+			d2J_dReferencedX.block(0,valid_points_count,6,1) = tmp_vector_6;
+
+			valid_points_count++;
+		} // if (outlierWeights(0,i) > 0.0)
+	}
+
+	Matrix d2J_dZdX(Matrix::Zero(6, 2 * valid_points_count));
+	d2J_dZdX.block(0,0,6,valid_points_count) = d2J_dReadingdX.block(0,0,6,valid_points_count);
+	d2J_dZdX.block(0,valid_points_count,6,valid_points_count) = d2J_dReferencedX.block(0,0,6,valid_points_count);
+
+	Matrix inv_J_hessian = J_hessian.inverse();
+
+	covariance = d2J_dZdX * d2J_dZdX.transpose();
+	covariance = inv_J_hessian * covariance * inv_J_hessian;
+
+	return (sensorStdDev * sensorStdDev) * covariance;
+}
+
+
+
+template<typename T>
+T ErrorMinimizersImpl<T>::PointToPlaneWithCovErrorMinimizer::getOverlap() const
+{
+	const int nbPoints = this->lastErrorElements.reading.features.cols();
+	const int dim = this->lastErrorElements.reading.features.rows();
+	if(nbPoints == 0)
+	{
+		throw std::runtime_error("Error, last error element empty. Error minimizer needs to be called at least once before using this method.");
+	}
+	
+	if (!this->lastErrorElements.reading.descriptorExists("simpleSensorNoise") ||
+		!this->lastErrorElements.reading.descriptorExists("normals"))
+	{
+		LOG_INFO_STREAM("PointToPlaneErrorMinimizer - warning, no sensor noise or normals found. Using best estimate given outlier rejection instead.");
+		return this->weightedPointUsedRatio;
+	}
+
+	const BOOST_AUTO(noises, this->lastErrorElements.reading.getDescriptorViewByName("simpleSensorNoise"));
+	const BOOST_AUTO(normals, this->lastErrorElements.reading.getDescriptorViewByName("normals"));
+	int count = 0;
+	for(int i=0; i < nbPoints; i++)
+	{
+		if(this->lastErrorElements.matches.dists(0, i) != numeric_limits<T>::infinity())
+		{
+			const Vector d = this->lastErrorElements.reading.features.col(i) - this->lastErrorElements.reference.features.col(i);
+			const Vector n = normals.col(i);
+			const T projectionDist = d.head(dim-1).dot(n.normalized());
+			if(anyabs(projectionDist) < noises(0,i))
+				count++;
+		}
+	}
+
+	return (T)count/(T)nbPoints;
+}
+
+template<typename T>
+typename ErrorMinimizersImpl<T>::Matrix ErrorMinimizersImpl<T>::PointToPlaneWithCovErrorMinimizer::getCovariance() const
+{
+  return covMatrix;
+}
+
+template struct ErrorMinimizersImpl<float>::PointToPlaneWithCovErrorMinimizer;
+template struct ErrorMinimizersImpl<double>::PointToPlaneWithCovErrorMinimizer;
+

--- a/pointmatcher/ErrorMinimizersImpl.h
+++ b/pointmatcher/ErrorMinimizersImpl.h
@@ -96,6 +96,56 @@ struct ErrorMinimizersImpl
 		virtual TransformationParameters compute(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches);
 		virtual T getOverlap() const;
 	};
+
+	struct PointToPointWithCovErrorMinimizer: ErrorMinimizer
+	{
+		inline static const std::string description()
+		{
+			return "Point-to-point error. Based on SVD decomposition. Based on \\cite{Besl1992Point2Point}. Covariance estimation based on \\cite{Censi2007ICPCovariance}.";
+		}
+
+		inline static const ParametersDoc availableParameters()
+		{
+			return boost::assign::list_of<ParameterDoc>
+				( "sensorStdDev", "sensor standard deviation", "0.01", "0.", "inf", &P::Comp<T>)
+			;
+		}
+
+	    const T sensorStdDev;
+		Matrix covMatrix;
+
+		PointToPointWithCovErrorMinimizer(const Parameters& params = Parameters());
+		virtual TransformationParameters compute(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches);
+		virtual T getOverlap() const;
+		virtual Matrix getCovariance() const;
+		Matrix estimateCovariance(const DataPoints& reading, const DataPoints& reference, const Matches& matches, const OutlierWeights& outlierWeights, const TransformationParameters& transformation);
+	};
+
+	struct PointToPlaneWithCovErrorMinimizer: public ErrorMinimizer
+	{
+		inline static const std::string description()
+		{
+			return "Point-to-plane error (or point-to-line in 2D). Based on \\cite{Chen1991Point2Plane}. Covariance estimation based on \\cite{Censi2007ICPCovariance}.";
+		}
+		
+		inline static const ParametersDoc availableParameters()
+		{
+			return boost::assign::list_of<ParameterDoc>
+				( "force2D", "If set to true(1), the minimization will be force to give a solution in 2D (i.e., on the XY-plane) even with 3D inputs.", "0", "0", "1", &P::Comp<bool>)
+				( "sensorStdDev", "sensor standard deviation", "0.01", "0.", "inf", &P::Comp<T>)
+			;
+		}
+
+		const bool force2D;
+	    const T sensorStdDev;
+		Matrix covMatrix;
+		
+		PointToPlaneWithCovErrorMinimizer(const Parameters& params = Parameters());
+		virtual TransformationParameters compute(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches);
+		virtual T getOverlap() const;
+		virtual Matrix getCovariance() const;
+		Matrix estimateCovariance(const DataPoints& reading, const DataPoints& reference, const Matches& matches, const OutlierWeights& outlierWeights, const TransformationParameters& transformation);
+	};
 }; // ErrorMinimizersImpl
 
 #endif // __POINTMATCHER_ERRORMINIMIZER_H

--- a/pointmatcher/PointMatcher.h
+++ b/pointmatcher/PointMatcher.h
@@ -468,6 +468,7 @@ struct PointMatcher
 		T getPointUsedRatio() const;
 		T getWeightedPointUsedRatio() const;
 		virtual T getOverlap() const;
+		virtual Matrix getCovariance() const;
 		
 		//! Find the transformation that minimizes the error
 		virtual TransformationParameters compute(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches) = 0;

--- a/pointmatcher/Registry.cpp
+++ b/pointmatcher/Registry.cpp
@@ -95,6 +95,8 @@ PointMatcher<T>::PointMatcher()
 	ADD_TO_REGISTRAR_NO_PARAM(ErrorMinimizer, IdentityErrorMinimizer, typename ErrorMinimizersImpl<T>::IdentityErrorMinimizer)
 	ADD_TO_REGISTRAR_NO_PARAM(ErrorMinimizer, PointToPointErrorMinimizer, typename ErrorMinimizersImpl<T>::PointToPointErrorMinimizer)
 	ADD_TO_REGISTRAR(ErrorMinimizer, PointToPlaneErrorMinimizer, typename ErrorMinimizersImpl<T>::PointToPlaneErrorMinimizer)
+	ADD_TO_REGISTRAR(ErrorMinimizer, PointToPointWithCovErrorMinimizer, typename ErrorMinimizersImpl<T>::PointToPointWithCovErrorMinimizer)
+	ADD_TO_REGISTRAR(ErrorMinimizer, PointToPlaneWithCovErrorMinimizer, typename ErrorMinimizersImpl<T>::PointToPlaneWithCovErrorMinimizer)
 	
 	ADD_TO_REGISTRAR(TransformationChecker, CounterTransformationChecker, typename TransformationCheckersImpl<T>::CounterTransformationChecker)
 	ADD_TO_REGISTRAR(TransformationChecker, DifferentialTransformationChecker, typename TransformationCheckersImpl<T>::DifferentialTransformationChecker)


### PR DESCRIPTION
Following the email conversation with Francois Pomerleau, I added two new errorMinimizers considering the covariance estimation according to ICP's result (PointToPointWithCovErrorMinimizer and PointToPlaneWithCovErrorMinimizer).
