### PR TITLE
Allow 2D descriptors

### DIFF
--- a/pointmatcher/InspectorsImpl.cpp
+++ b/pointmatcher/InspectorsImpl.cpp
@@ -194,7 +194,7 @@ void InspectorsImpl<T>::AbstractVTKInspector::dumpDataPoints(const DataPoints& d
 		{
 			buildScalarStream(stream, it->text, data);
 		}
-		else if(it->span == 3)
+		else if(it->span == 3 || it->span == 2)
 		{
 			buildVectorStream(stream, it->text, data);
 		}


### PR DESCRIPTION
Allow saving 2D descriptors coming from a 2Dmap, that are converted to 3D when writing to the file but needed after if we want to load the map as 2D.
