### PR TITLE
added application of reference data points filters for ICPSequence objects

### DIFF
--- a/pointmatcher/ICP.cpp
+++ b/pointmatcher/ICP.cpp
@@ -519,7 +519,15 @@ typename PointMatcher<T>::TransformationParameters PointMatcher<T>::ICPSequence:
 	
 	this->inspector->init();
 	
-	return this->computeWithTransformedReference(cloudIn, mapPointCloud, T_refIn_refMean, T_refIn_dataIn);
+	// Apply reference filters
+	// reference is express in frame <refIn>
+	DataPoints reference(mapPointCloud);
+	this->referenceDataPointsFilters.init();
+	this->referenceDataPointsFilters.apply(reference);
+	
+	this->matcher->init(reference);
+	
+	return this->computeWithTransformedReference(cloudIn, reference, T_refIn_refMean, T_refIn_dataIn);
 }
 
 template struct PointMatcher<float>::ICPSequence;


### PR DESCRIPTION
see issue #56.

Note that applying this change requires to go through the icp.yaml (and the like) files of a lot of existing setups (as in ethzasl_icp_mapping/ethzasl_icp_mapper/launch) and removing the reference data points filters. Otherwise I suppose that all this stuff will not work any more once the reference filters are active.
