### PR TITLE
Tim3xx laser support on Simple Noise filter

### DIFF
--- a/pointmatcher/DataPointsFiltersImpl.cpp
+++ b/pointmatcher/DataPointsFiltersImpl.cpp
@@ -1213,7 +1213,7 @@ DataPointsFiltersImpl<T>::SimpleSensorNoiseDataPointsFilter::SimpleSensorNoiseDa
 	sensorType(Parametrizable::get<unsigned>("sensorType")),
 	gain(Parametrizable::get<T>("gain"))
 {
-	std::vector<string> sensorNames = boost::assign::list_of ("Sick LMS-1xx")("Hokuyo URG-04LX")("Hokuyo UTM-30LX")("Kinect / Xtion");
+  std::vector<string> sensorNames = boost::assign::list_of ("Sick LMS-1xx")("Hokuyo URG-04LX")("Hokuyo UTM-30LX")("Kinect / Xtion")("Sick Tim3xx");
 	if (sensorType >= sensorNames.size())
 	{
 		throw InvalidParameter(
@@ -1267,6 +1267,11 @@ void DataPointsFiltersImpl<T>::SimpleSensorNoiseDataPointsFilter::inPlaceFilter(
 		noise = squaredValues*(0.5*0.00285);
 		break;
 	}
+  case 4: // Sick Tim3xx
+  {
+    noise = computeLaserNoise(0.004, 0.0053, -0.0092, cloud.features);
+    break;
+  }
 	default:
 		throw InvalidParameter(
 			(boost::format("SimpleSensorNoiseDataPointsFilter: Error, cannot compute noise for sensorType id %1% .") % sensorType).str());


### PR DESCRIPTION
I've added support for the Tim3xx laser sensor on the SimpleSensorNoiseDataPointsFilter.
I've obtained the values by taking several readings with the laser sensor stationary. Then, I've obtained mean and standard deviation of each ray. Finally, I've obtained a linear regression (from the linear portion) from plotting std. dev. as a function of the mean. Thus, I had an estimate sensor model which informs error as a function of distance.

Befere 2.5 meters I've estimated a constant error of 0.004m. Afterwards, the line parameters are -0.0092 offset and 0.053 slope.