### PR TITLE
completed the linking of the shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ else(APPLE)
 
 	if (SHARED_LIBS)
 		add_library(pointmatcher SHARED ${POINTMATCHER_SRC} ${POINTMATCHER_HEADERS})
+		target_link_libraries(pointmatcher ${Boost_LIBRARIES} ${NABO_LIBRARY})
 		install(TARGETS pointmatcher LIBRARY DESTINATION ${INSTALL_LIB_DIR})
 	else(SHARED_LIBS)
 		add_library(pointmatcher ${POINTMATCHER_SRC} ${POINTMATCHER_HEADERS} )


### PR DESCRIPTION
Without this the shared library on will be incomplete (have unresolved symbols). This is fine _if_ one correctly (potentially including order!) provides all the missing shared libraries when linking a final executable, which needs to be complete.

This fails for example because the build system is messing up the order of the shared libraries dependencies. For example catkin will produce in unlucky situations a wrong sequence of the shared libraries resulting in a linking error (e.g. undefined libnabo symbols) for the final executable.

Btw: The order constraint for the gnu linker ```ld``` (when invoked with ```--as-needed```, which is default for ```g++``` or ```gcc```) is to have libnabo at least once behind the first libpointmatcher in the list of shared libraries.