### PR TITLE
Make Windows compilation instructions a bit more explicit

### DIFF
--- a/doc/CompilationWindows.md
+++ b/doc/CompilationWindows.md
@@ -34,7 +34,7 @@ grep --version
 ```
 
 ### Building Boost
-1. Open a console that knows the path to the MSVC compiler command (cl). We suggest to use **Windows PowerShell**. An alternative is from the Start menu in the Visual Studio section; for instance for VS 2012, it is called Developer Command Prompt for VS2012.
+1. Open a console that knows the path to the MSVC compiler command (cl). We suggest using **Windows PowerShell**. An alternative is **Developer Command Prompt**, which can be located in the Start menu in the Visual Studio section.
 1. Go to your Boost source directory, and do:
 
     ```
@@ -42,17 +42,19 @@ grep --version
     $ b2 install --prefix=build address-model=64
     ```
 
-1. It may take awhile to finish.
+1. It may take a while to finish.
 
 
 ### Build libnabo 
-1. Start **CMake Gui**
+1. Start **CMake GUI**
 
-1. Add the path of your libnabo sources in the field _Where is the source code_.
+1. Add the path of your libnabo source folder in the field _Where is the source code_.
 1. Add a folder named build in the field _Where to build the binary_. This will allow you to do out-of-source compilation.
 1. Click on the button Configure
     1. Select the generator for the project (Visual Studio 11 Win 64)
-    1. Error will be reported, because CMake does not know yet where to find the libraries. The next steps will tell it where to find them.
+    1. Typically you will select "Use default native compilers" for the generator
+    1. Click "Finish"
+    1. An error will be reported, because CMake does not know yet where to find the libraries. The next steps will tell it where to find them.
 
 1. Locate _your eigen folder_ in the field **EIGEN_INCLUDE_DIR**
 
@@ -64,47 +66,47 @@ grep --version
 
 1. Click on the button Configure again, then on Generate
 
-1. Locate the Microsoft Visual Studio Solution file in the your build folder (libnabo.sln) and open it. Visual Studio should open.
+1. Locate the Microsoft Visual Studio Solution file (libnabo.sln) in the your build folder and open it. Visual Studio should open.
 
 1. Build the solution: BUILD -> Build Solution
 
-    Command line alternative for building: in _(your libnabo folder)_/build:
+    Alternatively, you can build the solution from the command line. In _(your libnabo folder)_/build:
     
     ```
     $ msbuild /m:2 libnabo.sln
     ```
     
-    Note that the flag /m:X defines the number of core to use.
-    
+    (Note that the flag /m:X defines the number of cores msbuild will use while building the solution.)
+
 
 ### Building yaml-cpp
-1. Start CMake Gui, follow the same building step
+1. Start **CMake GUI**, follow the same steps to configure the source and build folders for _yaml-cpp_, then click the Configure button.
 
 1. Change the variable **CMAKE_CONFIGURATION_TYPES** to `RelWithDebInfo`
 
 1. Click on the button Configure, then on Generate
 
-1. In visual Studio, build the solution: BUILD -> Build Solution
+1. In Visual Studio, build the solution: BUILD -> Build Solution
 
-    Command line alternative: in _(your yaml-cpp folder)_/build:
+    Alternatively, you can build the solution from the command line. In _(your yaml-cpp folder)_/build:
     
     ```
     $ msbuild /m:2 YAML_CPP.sln
     ```
     
-    Note that the flag /m:X defines the number of core to use.
-    
+    (Note that the flag /m:X defines the number of cores msbuild will use while building the solution.)
+
 
 ### Building gtest
-1. Open the file CMakeList.txt and add at the end:
+1. Open the file CMakeLists.txt and add at the end:
 
     ```
     if( MSVC ) # VS2012 does not support tuples correctly yet
     	   add_definitions( /D _VARIADIC_MAX=10 )
     endif()
     ```
-    
-1. Start CMake-Gui to generate a MSVC solution
+
+1. Start **CMake GUI**, follow the same steps to configure the source and build folders for _gtest_, then click the Configure button.
 
 1. Change the variable **CMAKE_CONFIGURATION_TYPES** to `RelWithDebInfo`
 
@@ -112,47 +114,48 @@ grep --version
 
 1. Click on the button Configure, then on Generate
 
-1. In visual Studio, build the solution: BUILD -> Build Solution
+1. In Visual Studio, build the solution: BUILD -> Build Solution
 
-    Command line alternative: in _(your gtest folder)_/build:
+    Alternatively, you can build the solution from the command line. In _(your gtest folder)_/build:
     
     ```
     $ msbuild /m:2 gtest.sln
     ```
     
-    Note that the flag /m:X defines the number of core to use.
-    
-### Build libpointmatcher
-1. Start CMake Gui
+    (Note that the flag /m:X defines the number of cores msbuild will use while building the solution.)
 
-1. Follow the same building steps
+
+### Build libpointmatcher
+1. Start **CMake GUI**, follow the same steps to configure the source and build folders for _libpointmatcher_, then click the Configure button.
 
 1. Add the following boolean variable and set it to true: Boost_USE_STATIC_LIBS
 
-1. Add the following PATH variable and set it to [boost folder]/build: BOOST_ROOT
+1. Add the following PATH variable and set it to _(your Boost folder)_/build: BOOST_ROOT
 
 1. Change the variable **CMAKE_CONFIGURATION_TYPES** to `RelWithDebInfo`
 
-1. You will need to fill manually the following variables:
-    
-    1. **EIGEN_INCLUDE_DIR** to _(your eigen folder)_
-    1. **NABO_INCLUDE_DIR** to _(your nabo folder)_
-    1. **NABO_LIBRARY** to _(your nabo folder)_/build/RelWithDebInfo/nabo.lib
-    1. **yaml-cpp_INCLUDE_DIRS**
-    1. **yaml-cpp_LIBRARIES**
-    1. **GTEST_INCLUDE_DIR**
-    1. **GTEST_LIBRARY**
-    1. **GTEST_MAIN_LIBRARY**
-    
-1. In visual Studio, build the solution: BUILD -> Build Solution
+1. You will need to manually add and set the following variables:
 
-    Command line alternative: in _(your libpointmatcher folder)_/build:
+    1. **EIGEN_INCLUDE_DIR** (PATH type) to _(your eigen source folder)_
+    1. **NABO_INCLUDE_DIR** (PATH type) to _(your libnabo source folder)_
+    1. **NABO_LIBRARY** (FILEPATH type) to _(your libnabo source folder)_/build/RelWithDebInfo/nabo.lib
+    1. **libnabo_DIR** will automatically be set to your libnabo build folder
+    1. **yaml-cpp_INCLUDE_DIRS** (PATH type) to _(your yaml-cpp source folder)_
+    1. **yaml-cpp_LIBRARIES** (FILEPATH type) to _(your yaml-cpp source folder)_/build/RelWithDebInfo/libyaml-cppmd.lib
+    1. **GTEST_INCLUDE_DIR** (PATH type) to _(your gtest source folder)_
+    1. **GTEST_LIBRARY** (FILEPATH type) to _(your gtest source folder)_/build/RelWithDebInfo/gtest.lib
+    1. **GTEST_MAIN_LIBRARY** (FILEPATH type) to _(your gtest source folder)_/build/RelWithDebInfo/gtest_main.lib
+
+1. In Visual Studio, build the solution: BUILD -> Build Solution
+
+    Alternatively, you can build the solution from the command line. In _(your libpointmatcher folder)_/build:
     
     ```
     $ msbuild /m:2 libpointmatcher.sln
     ```
     
-    Note that the flag /m:X defines the number of core to use.
+    (Note that the flag /m:X defines the number of cores msbuild will use while building the solution.)
+
 
 ## Reporting Issues
 


### PR DESCRIPTION
These are some minor tweaks to the Windows compilation instructions for anyone (like me) less familiar with the toolchain.

Note that I am currently having an SLN generation issue (https://github.com/ethz-asl/libpointmatcher/issues/101) with libpointmatcher itself, so the instructions for the final step should be double-checked for correctness.