### PR TITLE
Fix/some cmake file installation problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,8 +365,12 @@ install(
 )
 
 # useful for TRADR european project. TODO: check to use the other install
-install (FILES "${PROJECT_BINARY_DIR}/libpointmatcherConfig.cmake" DESTINATION "share/${PROJECT_NAME}/cmake/")
-
+# required for ros deployment, too
+install (
+  FILES 
+    "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/libpointmatcherConfig.cmake" 
+  DESTINATION "share/${PROJECT_NAME}/cmake/"
+)
 
 #====================== uninstall target ===============================
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,10 @@ set(CONF_INCLUDE_DIRS ${INSTALL_INCLUDE_DIR} ${CONF_INCLUDE_DIRS} )
 # because we added an include for the local yaml-cpp-pm we should also remove it
 list(REMOVE_ITEM CONF_INCLUDE_DIRS ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/contrib/yaml-cpp-pm/include)
 
+if(SHARED_LIBS AND (NOT USE_SYSTEM_YAML_CPP))
+  list(REMOVE_ITEM EXTERNAL_LIBS ${yaml-cpp-pm_LIB})
+endif(SHARED_LIBS AND (NOT USE_SYSTEM_YAML_CPP))
+
 # Change the library location for an install location
 get_filename_component(POINTMATCHER_LIB_NAME ${POINTMATCHER_LIB} NAME)
 set(POINTMATCHER_LIB ${INSTALL_LIB_DIR}/${POINTMATCHER_LIB_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,7 @@ install(
 install (
   FILES 
     "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/libpointmatcherConfig.cmake" 
+    "${PROJECT_BINARY_DIR}/libpointmatcherConfigVersion.cmake" 
   DESTINATION "share/${PROJECT_NAME}/cmake/"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,10 +357,12 @@ configure_file(libpointmatcherConfigVersion.cmake.in
  
 
 # Install the libpointmatcherConfig.cmake and libpointmatcherConfigVersion.cmake
-install(FILES
-   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/libpointmatcherConfig.cmake"
-	 "${PROJECT_BINARY_DIR}/libpointmatcherConfigVersion.cmake"
-		   DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
+install(
+  FILES
+    "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/libpointmatcherConfig.cmake"
+    "${PROJECT_BINARY_DIR}/libpointmatcherConfigVersion.cmake"
+  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev
+)
 
 # useful for TRADR european project. TODO: check to use the other install
 install (FILES "${PROJECT_BINARY_DIR}/libpointmatcherConfig.cmake" DESTINATION "share/${PROJECT_NAME}/cmake/")


### PR DESCRIPTION
There were issues with the installation I try to fix here:
* The local ```libpointmatcherConfig.cmake``` was installed to ```share/${PROJECT_NAME}/cmake/```. This fix here (0eee5a5) should solve https://github.com/ethz-asl/ethzasl_icp_mapping/issues/34
* The ```libpointmatcherConfigVersion.cmake``` was not installed into ```share/${PROJECT_NAME}/cmake/```, but for example if it gets distributed via ros debian package nobody will find it at the other place (```lib/cmake/pointmatcher ```)
* The local archive file of yaml-cpp-pm (in case of using the contributed lib yaml) was part of the ```pointmatcher_LIBRARIES``` variable in the installed ```libpointmatcherConfig.cmake```. This can be safely remove in case of a shared libpointmatcher library because it is already fully linked to it. In case of a static it's different but we don't have a clean solution for that as we don't install the yaml-cpp-pm archive.
