### PR TITLE
Handle the degenerate situation when the residuals are 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The library has a light dependency list:
 
  * [Eigen] version 3, a modern C++ matrix and linear-algebra library,
  * [boost] version 1.48 and up, portable C++ source libraries,
- * [libnabo] version 1.0.1, a fast K Nearest Neighbour library for low-dimensional spaces,
+ * [libnabo] version 1.0.6, a fast K Nearest Neighbour library for low-dimensional spaces,
  
 and was compiled on:
   * Ubuntu ([see how](/doc/Compilation.md))

--- a/examples/data/default-identity.yaml
+++ b/examples/data/default-identity.yaml
@@ -1,0 +1,38 @@
+readingDataPointsFilters:
+  - IdentityDataPointsFilter:
+
+referenceDataPointsFilters:
+  - SamplingSurfaceNormalDataPointsFilter:
+      knn: 10
+      ratio: 1.0 
+      samplingMethod: 0
+      averageExistingDescriptors: 0
+
+matcher:
+  KDTreeMatcher:
+    knn: 1
+    epsilon: 0 
+
+outlierFilters:
+  - TrimmedDistOutlierFilter:
+      ratio: 1.0
+
+errorMinimizer:
+  PointToPlaneErrorMinimizer
+
+transformationCheckers:
+  - CounterTransformationChecker:
+      maxIterationCount: 40
+  - DifferentialTransformationChecker:
+      minDiffRotErr: 0.001
+      minDiffTransErr: 0.01
+      smoothLength: 4   
+      
+inspector:
+  NullInspector
+#  VTKFileInspector
+
+logger:
+  NullLogger
+#  FileLogger
+

--- a/pointmatcher/ErrorMinimizersImpl.cpp
+++ b/pointmatcher/ErrorMinimizersImpl.cpp
@@ -246,8 +246,8 @@ typename PointMatcher<T>::TransformationParameters ErrorMinimizersImpl<T>::Point
 		{
 			// Degenerate situation. This can happen when the source and reading clouds
 			// are identical, and then b and x above are 0, and the rotation matrix cannot
-			// be determined, it comes out full of NaNs. The correct transform is the identity.
-			mOut = Matrix::Identity(dim, dim);
+			// be determined, it comes out full of NaNs. The correct rotation is the identity.
+			mOut.block(0, 0, dim-1, dim-1) = Matrix::Identity(dim-1, dim-1);
 		}	
 	}
 	else
@@ -269,12 +269,6 @@ typename PointMatcher<T>::TransformationParameters ErrorMinimizersImpl<T>::Point
 
 	}
 
-	if (mOut != mOut) 
-	{
-		// Degenerate situation, for example, when all residuals are zero. The matrix
-		// is full of NaNs. The correct transform is the identity.
-		mOut = Matrix::Identity(dim, dim);
-	}
 	return mOut; 
 }
 

--- a/pointmatcher/ErrorMinimizersImpl.cpp
+++ b/pointmatcher/ErrorMinimizersImpl.cpp
@@ -241,6 +241,14 @@ typename PointMatcher<T>::TransformationParameters ErrorMinimizersImpl<T>::Point
 		std::cerr << "d angles" << x(0) - roll << ", " << x(1) - pitch << "," << x(2) - yaw << std::endl;*/
 		transform.translation() = x.segment(3, 3);
 		mOut = transform.matrix();
+
+		if (mOut != mOut) 
+		{
+			// Degenerate situation. This can happen when the source and reading clouds
+			// are identical, and then b and x above are 0, and the rotation matrix cannot
+			// be determined, it comes out full of NaNs. The correct transform is the identity.
+			mOut = Matrix::Identity(dim, dim);
+		}	
 	}
 	else
 	{

--- a/pointmatcher/ErrorMinimizersImpl.cpp
+++ b/pointmatcher/ErrorMinimizersImpl.cpp
@@ -258,6 +258,14 @@ typename PointMatcher<T>::TransformationParameters ErrorMinimizersImpl<T>::Point
 		{
 			mOut = transform.matrix();
 		}
+
+	}
+
+	if (mOut != mOut) 
+	{
+		// Degenerate situation, for example, when all residuals are zero. The matrix
+		// is full of NaNs. The correct transform is the identity.
+		mOut = Matrix::Identity(dim, dim);
 	}
 	return mOut; 
 }

--- a/pointmatcher/Matches.cpp
+++ b/pointmatcher/Matches.cpp
@@ -70,7 +70,12 @@ T PointMatcher<T>::Matches::getDistsQuantile(const T quantile) const
 	if (values.size() == 0)
 		throw ConvergenceError("no outlier to filter");
 	
+	if (quantile < 0.0 || quantile > 1.0)
+		throw ConvergenceError("quantile must be between 0 and 1");
+
 	// get quantile
+	if (quantile == 1.0)
+		return *max_element(values.begin(), values.end());
 	nth_element(values.begin(), values.begin() + (values.size() * quantile), values.end());
 	return values[values.size() * quantile];
 }

--- a/utest/utest.cpp
+++ b/utest/utest.cpp
@@ -147,7 +147,26 @@ TEST(icpTest, icpTest)
 		EXPECT_LT(transErr, transTol) << "This error was caused by the test file:" <<  endl << "   " << config_file;
 	}
 }
+TEST(icpTest, icpIdentity)
+{
+	// Here we test point-to-plane ICP where we expect the output transform to be 
+	// the identity. This situation requires special treatment in the algorithm.
+	
+	DP pts0 = DP::load(dataPath + "cloud.00000.vtk");
+	DP pts1 = DP::load(dataPath + "cloud.00000.vtk");
 
+	PM::ICP icp;
+	std::string config_file = dataPath + "default-identity.yaml";
+	EXPECT_TRUE(boost::filesystem::exists(config_file));
+
+	std::ifstream ifs(config_file.c_str());
+	EXPECT_NO_THROW(icp.loadFromYaml(ifs)) << "This error was caused by the test file:" << endl << "   " << config_file;
+
+	// Compute current ICP transform
+	PM::TransformationParameters curT = icp(pts0, pts1);
+    
+	EXPECT_EQ(curT, PM::Matrix::Identity(4,4)) << "Expecting identity transform." << endl;
+}
 
 TEST(icpTest, icpSequenceTest)
 {
@@ -191,9 +210,6 @@ TEST(icpTest, icpSequenceTest)
 	map = icpSequence.getInternalMap();
 	EXPECT_EQ(map.getNbPoints(), 0u);
 	EXPECT_EQ(map.getHomogeneousDim(), 0u);
-
-
-
 }
 
 // Utility classes


### PR DESCRIPTION
I found that point-to-plane alignment fails when one tries to align a point cloud to itself. The reason is that all the residuals are zero, and Eigen::AxisAngle when applied to a zero vector returns an invalid rotation, full of NaNs. The fix is to just return the identity alignment transform.

