### PR TITLE
Handle the degenerate situation when the residuals are 0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The library has a light dependency list:
 
  * [Eigen] version 3, a modern C++ matrix and linear-algebra library,
  * [boost] version 1.48 and up, portable C++ source libraries,
- * [libnabo] version 1.0.1, a fast K Nearest Neighbour library for low-dimensional spaces,
+ * [libnabo] version 1.0.6, a fast K Nearest Neighbour library for low-dimensional spaces,
  
 and was compiled on:
   * Ubuntu ([see how](/doc/Compilation.md))

--- a/examples/data/default-identity.yaml
+++ b/examples/data/default-identity.yaml
@@ -1,0 +1,38 @@
+readingDataPointsFilters:
+  - IdentityDataPointsFilter:
+
+referenceDataPointsFilters:
+  - SamplingSurfaceNormalDataPointsFilter:
+      knn: 10
+      ratio: 1.0 
+      samplingMethod: 0
+      averageExistingDescriptors: 0
+
+matcher:
+  KDTreeMatcher:
+    knn: 1
+    epsilon: 0 
+
+outlierFilters:
+  - TrimmedDistOutlierFilter:
+      ratio: 1.0
+
+errorMinimizer:
+  PointToPlaneErrorMinimizer
+
+transformationCheckers:
+  - CounterTransformationChecker:
+      maxIterationCount: 40
+  - DifferentialTransformationChecker:
+      minDiffRotErr: 0.001
+      minDiffTransErr: 0.01
+      smoothLength: 4   
+      
+inspector:
+  NullInspector
+#  VTKFileInspector
+
+logger:
+  NullLogger
+#  FileLogger
+

--- a/pointmatcher/ErrorMinimizersImpl.cpp
+++ b/pointmatcher/ErrorMinimizersImpl.cpp
@@ -241,6 +241,14 @@ typename PointMatcher<T>::TransformationParameters ErrorMinimizersImpl<T>::Point
 		std::cerr << "d angles" << x(0) - roll << ", " << x(1) - pitch << "," << x(2) - yaw << std::endl;*/
 		transform.translation() = x.segment(3, 3);
 		mOut = transform.matrix();
+
+		if (mOut != mOut) 
+		{
+			// Degenerate situation. This can happen when the source and reading clouds
+			// are identical, and then b and x above are 0, and the rotation matrix cannot
+			// be determined, it comes out full of NaNs. The correct rotation is the identity.
+			mOut.block(0, 0, dim-1, dim-1) = Matrix::Identity(dim-1, dim-1);
+		}	
 	}
 	else
 	{

--- a/pointmatcher/Matches.cpp
+++ b/pointmatcher/Matches.cpp
@@ -70,7 +70,12 @@ T PointMatcher<T>::Matches::getDistsQuantile(const T quantile) const
 	if (values.size() == 0)
 		throw ConvergenceError("no outlier to filter");
 	
+	if (quantile < 0.0 || quantile > 1.0)
+		throw ConvergenceError("quantile must be between 0 and 1");
+
 	// get quantile
+	if (quantile == 1.0)
+		return *max_element(values.begin(), values.end());
 	nth_element(values.begin(), values.begin() + (values.size() * quantile), values.end());
 	return values[values.size() * quantile];
 }

--- a/utest/utest.cpp
+++ b/utest/utest.cpp
@@ -147,7 +147,26 @@ TEST(icpTest, icpTest)
 		EXPECT_LT(transErr, transTol) << "This error was caused by the test file:" <<  endl << "   " << config_file;
 	}
 }
+TEST(icpTest, icpIdentity)
+{
+	// Here we test point-to-plane ICP where we expect the output transform to be 
+	// the identity. This situation requires special treatment in the algorithm.
+	
+	DP pts0 = DP::load(dataPath + "cloud.00000.vtk");
+	DP pts1 = DP::load(dataPath + "cloud.00000.vtk");
 
+	PM::ICP icp;
+	std::string config_file = dataPath + "default-identity.yaml";
+	EXPECT_TRUE(boost::filesystem::exists(config_file));
+
+	std::ifstream ifs(config_file.c_str());
+	EXPECT_NO_THROW(icp.loadFromYaml(ifs)) << "This error was caused by the test file:" << endl << "   " << config_file;
+
+	// Compute current ICP transform
+	PM::TransformationParameters curT = icp(pts0, pts1);
+    
+	EXPECT_EQ(curT, PM::Matrix::Identity(4,4)) << "Expecting identity transform." << endl;
+}
 
 TEST(icpTest, icpSequenceTest)
 {
@@ -191,9 +210,6 @@ TEST(icpTest, icpSequenceTest)
 	map = icpSequence.getInternalMap();
 	EXPECT_EQ(map.getNbPoints(), 0u);
 	EXPECT_EQ(map.getHomogeneousDim(), 0u);
-
-
-
 }
 
 // Utility classes


### PR DESCRIPTION
I wiped the previous pull request, and made a new one to be in sync with the latest upstream changes (I could have just appended to that request I guess, but it is cleaner this way).

To summarize, the bug here actually shows up very rarely. I did add a unit test which reproduces it. In order for this issue to show up, one must use point-to-plane alignment, have the two clouds to align be identical, and any filtering which removes points must be turned off. Then, the Eigen::AngleAxis() function cannot create a rotation from a zero vector. The correct rotation is the identity though.

The bug does not show up if one cloud is translated in respect to the other one. Numerical noise results in a non-zero (but very small) rotation matrix.

The bug does not show up either with point-to-point alignment when the clouds are identical.

I fixed one more small issue. The function Matches::getDistsQuantile(const T quantile) did not return the correct answer if quartile = 1.0. That was not issue until now, but could be from now on, since the ratio in filtering is now allowed to be 1 per the previous fix.
