### PR TITLE
fix PointMatcher: SVD can return a reflection instead of a rotation

### DIFF
--- a/pointmatcher/ErrorMinimizersImpl.cpp
+++ b/pointmatcher/ErrorMinimizersImpl.cpp
@@ -86,7 +86,15 @@ typename PointMatcher<T>::TransformationParameters ErrorMinimizersImpl<T>::Point
 	// Singular Value Decomposition
 	const Matrix m(mPts.reference.features.topRows(dimCount-1) * mPts.reading.features.topRows(dimCount-1).transpose());
 	const JacobiSVD<Matrix> svd(m, ComputeThinU | ComputeThinV);
-	const Matrix rotMatrix(svd.matrixU() * svd.matrixV().transpose());
+	Matrix rotMatrix(svd.matrixU() * svd.matrixV().transpose());
+	//It is possible to get a reflection instead of a rotation. in this case we
+	//take the second best solution, guaranteed to be a rotation
+	if (rotMatrix.determinant() < 0.)
+	{
+		Matrix tmpV = svd.matrixV().transpose();
+		tmpV.row(dimCount-2) *= -1.;
+		rotMatrix = svd.matrixU() * tmpV;
+	}
 	const Vector trVector(meanReference.head(dimCount-1)- rotMatrix * meanReading.head(dimCount-1));
 	
 	Matrix result(Matrix::Identity(dimCount, dimCount));


### PR DESCRIPTION
Hi
The SVD in the point matcher can return a reflection instead of a rotation (det=-1 instead of det=1). This later causes the exception "Error, rotation matrix is not orthogonal." due to det(rotationmatrix) = -1.
This fixes it by taking the second best solution of the SVD, guaranteed to be a rotation.
see also: http://igl.ethz.ch/projects/ARAP/svd_rot.pdf