### PR TITLE
Removed outdated install line that was apparently accidentelly introduced in PR #109 (d199aaaf9).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,8 +377,6 @@ install (
   DESTINATION "share/${PROJECT_NAME}/cmake/"
 )
 
-install (FILES "${PROJECT_BINARY_DIR}/libpointmatcherConfig.cmake" DESTINATION "share/${PROJECT_NAME}/cmake/")
-
 #Handle pkg-config file
 CONFIGURE_FILE(pointmatcher.pc.in pointmatcher.pc @ONLY)
 INSTALL(FILES ${CMAKE_BINARY_DIR}/pointmatcher.pc DESTINATION lib/pkgconfig)


### PR DESCRIPTION
The new one is right above it. So we don't need it. In fact it seems to override the one above.