### PR TITLE
Support binary VTK legacy files

### DIFF
--- a/pointmatcher/IO.cpp
+++ b/pointmatcher/IO.cpp
@@ -887,14 +887,18 @@ void PointMatcher<T>::DataPoints::save(const std::string& fileName, bool binary)
 	const string& ext(boost::filesystem::extension(path));
 	if (boost::iequals(ext, ".vtk"))
 		return PointMatcherIO<T>::saveVTK(*this, fileName, binary);
-	else if (boost::iequals(ext, ".csv"))
+
+	if (binary)
+		throw runtime_error("save(): Binary writing is not supported together with extension \"" + ext + "\". Currently binary writing is only supported with \".vtk\".");
+
+	if (boost::iequals(ext, ".csv"))
 		return PointMatcherIO<T>::saveCSV(*this, fileName);
 	else if (boost::iequals(ext, ".ply"))
 		return PointMatcherIO<T>::savePLY(*this, fileName);
 	else if (boost::iequals(ext, ".pcd"))
 		return PointMatcherIO<T>::savePCD(*this, fileName);
 	else
-		throw runtime_error("saveAnyFormat(): Unknown extension \"" + ext + "\" for file \"" + fileName + "\", extension must be either \".vtk\" or \".csv\"");
+		throw runtime_error("save(): Unknown extension \"" + ext + "\" for file \"" + fileName + "\", extension must be either \".vtk\", \".ply\", \".pcd\" or \".csv\"");
 }
 
 template

--- a/pointmatcher/IO.cpp
+++ b/pointmatcher/IO.cpp
@@ -986,6 +986,28 @@ typename PointMatcher<T>::DataPoints PointMatcherIO<T>::loadVTK(const std::strin
 	return loadVTK(ifs);
 }
 
+void skipBlock(bool binary, int binarySize, std::istream & is, bool hasSeparateSizeParameter = true){
+	int n;
+	int size;
+	is >> n;
+	if(hasSeparateSizeParameter) {
+		is >> size;
+	} else {
+		size = n;
+	}
+
+	std::string line;
+	getline(is, line); // remove line end after parameters;
+	if(binary){
+		is.seekg(size * binarySize, std::ios_base::cur);
+	} else {
+		for (int p = 0; p < n; p++)
+		{
+			getline(is, line);
+		}
+	}
+}
+
 //! Load point cloud from a stream as VTK
 template<typename T>
 typename PointMatcher<T>::DataPoints PointMatcherIO<T>::loadVTK(std::istream& is)
@@ -1002,8 +1024,13 @@ typename PointMatcher<T>::DataPoints PointMatcherIO<T>::loadVTK(std::istream& is
 		throw runtime_error(string("Wrong magic header, found ") + line);
 	getline(is, line);
 	getline(is, line);
-	if (line != "ASCII")
-		throw runtime_error(string("Wrong file type, expecting ASCII, found ") + line);
+
+	const bool isBinary = (line == "BINARY");
+	if (line != "ASCII"){
+		if(!isBinary){
+			throw runtime_error(string("Wrong file type, expecting ASCII or BINARY, found ") + line);
+		}
+	}
 	getline(is, line);
 
 	SupportedVTKDataTypes dataType;
@@ -1030,16 +1057,15 @@ typename PointMatcher<T>::DataPoints PointMatcherIO<T>::loadVTK(std::istream& is
 		{
 			is >> pointCount;
 			is >> type;
-			
+			getline(is, line); // remove line end after parameters!
+
 			if(!(type == "float" || type == "double"))
 					throw runtime_error(string("Field POINTS can only be of type double or float"));
 
 			Matrix features(4, pointCount);
 			for (int p = 0; p < pointCount; ++p)
 			{
-				is >> features(0, p);
-				is >> features(1, p);
-				is >> features(2, p);
+				readVtkData(type, isBinary, features.template block<3, 1>(0, p), is);
 				features(3, p) = 1.0;
 			}
 			loadedPoints.addFeature("x", features.row(0));
@@ -1053,86 +1079,32 @@ typename PointMatcher<T>::DataPoints PointMatcherIO<T>::loadVTK(std::istream& is
 		// POLYDATA
 		else if(dataType == POLYDATA && fieldName == "VERTICES")
 		{
-			int size;
-			int verticeSize;
-			is >> size >> verticeSize;
-			// Skip vertice definition
-			for (int p = 0; p < size; p++)
-			{
-				getline(is, line); 
-				if(line == "")
-					p--;
-			}
+			skipBlock(isBinary, 4, is);
 		}
 
 		else if(dataType == POLYDATA && fieldName == "LINES")
 		{
-			int size;
-			int lineSize;
-			is >> size >> lineSize;
-			// Skip line definition
-			for (int p = 0; p < size; p++)
-			{
-				getline(is, line);
-				if(line == "")
-					p--;
-			}
+			skipBlock(isBinary, 4, is);
 		}
 
 		else if(dataType == POLYDATA && fieldName == "POLYGONS")
 		{
-			int size;
-			int polySize;
-			is >> size >> polySize;
-			// Skip line definition
-			for (int p = 0; p < size; p++)
-			{
-				getline(is, line);
-				if(line == "")
-					p--;
-			}
+			skipBlock(isBinary, 4, is);
 		}
 
 		else if(dataType == POLYDATA && fieldName == "TRIANGLE_STRIPS")
 		{
-			int size;
-			int stripSize;
-			is >> size >> stripSize;
-			// Skip line definition
-			for (int p = 0; p < size; p++)
-			{
-				getline(is, line);
-				if(line == "")
-					p--;
-			}
+			skipBlock(isBinary, 4, is);
 		}
 
 		// Unstructure Grid
 		else if(dataType == UNSTRUCTURED_GRID && fieldName == "CELLS")
 		{
-			int size;
-			int cellSize;
-			is >> size >> cellSize;
-			// Skip line definition
-			for (int p = 0; p < size; p++)
-			{
-				getline(is, line);
-				if(line == "")
-					p--;
-			}
+			skipBlock(isBinary, 4, is);
 		}
 		else if(dataType == UNSTRUCTURED_GRID && fieldName == "CELL_TYPES")
 		{
-			int size;
-			int cellSize;
-			is >> size >> cellSize;
-			// Skip line definition
-			for (int p = 0; p < size; p++)
-			{
-				getline(is, line);
-				if(line == "")
-					p--;
-			}
+			skipBlock(isBinary, 4, is, false); // according to http://www.vtk.org/VTK/img/file-formats.pdf CELL_TYPES only has one parameter (n)
 		}
 
 		//////////////////////////////////////////////////////////
@@ -1160,10 +1132,14 @@ typename PointMatcher<T>::DataPoints PointMatcherIO<T>::loadVTK(std::istream& is
 
 				if(type == "vtkIdType") // skip that type
 				{
-					int t_val;
-					for (int t = 0; t < dim * numTuples; t++ )
-					{
-						is >> t_val;
+					if(isBinary){
+						is.seekg(dim * numTuples * 4, std::ios_base::cur);
+					} else {
+						int t_val;
+						for (int t = 0; t < dim * numTuples; t++ )
+						{
+							is >> t_val;
+						}
 					}
 				}
 				else if(!(type == "float" || type == "double"))
@@ -1171,13 +1147,7 @@ typename PointMatcher<T>::DataPoints PointMatcherIO<T>::loadVTK(std::istream& is
 						 
 
 				Matrix descriptor(dim, pointCount);
-				for (int p = 0; p < pointCount; ++p)
-				{
-					for(int d = 0; d < dim; d++)
-					{
-						is >> descriptor(d, p);
-					}
-				}
+				readVtkData(type, isBinary, descriptor.transpose(), is);
 				loadedPoints.addDescriptor(name, descriptor);
 			}
 		}
@@ -1187,6 +1157,7 @@ typename PointMatcher<T>::DataPoints PointMatcherIO<T>::loadVTK(std::istream& is
 			is >> name;
 
 			bool skipLookupTable = false;
+			bool isColorScalars = false;
 			if(fieldName == "SCALARS")
 			{
 				dim = 1;
@@ -1212,33 +1183,36 @@ typename PointMatcher<T>::DataPoints PointMatcherIO<T>::loadVTK(std::istream& is
 			{
 				is >> dim;
 				type = "float";
+				isColorScalars = true;
 			}
 			else
 				throw runtime_error(string("Unknown field name " + fieldName + ", expecting SCALARS, VECTORS, TENSORS, NORMALS or COLOR_SCALARS."));
 
 			
-			if(!(type == "float" || type == "double"))
-					throw runtime_error(string("Field " + fieldName + " is " + type + " but can only be of type double or float"));
-					 
-			// Skip LOOKUP_TABLE line
-			if(skipLookupTable)
-			{
-				//FIXME: FP - why the first line is aways empty?
-				getline(is, line); 
-				getline(is, line); 
-			}
+			getline(is, line); // remove rest of the parameter line including its line end;
 
 			Matrix descriptor(dim, pointCount);
-			for (int p = 0; p < pointCount; ++p)
-			{
-				for(int d = 0; d < dim; d++)
-				{
-					is >> descriptor(d, p);
+			if(isColorScalars && isBinary) {
+				std::vector<unsigned char> buffer(dim);
+				for (int i = 0; i < pointCount; ++i){
+					is.read(reinterpret_cast<char *>(&buffer.front()), dim);
+					for(int r=0; r < dim; ++r){
+						descriptor(r, i) = buffer[r] / static_cast<T>(255.0);
+					}
 				}
+			} else {
+				if(!(type == "float" || type == "double"))
+						throw runtime_error(string("Field " + fieldName + " is " + type + " but can only be of type double or float"));
+
+				// Skip LOOKUP_TABLE line
+				if(skipLookupTable)
+				{
+					getline(is, line);
+				}
+				readVtkData(type, isBinary, descriptor.transpose(), is);
 			}
 			loadedPoints.addDescriptor(name, descriptor);
 		}
-			 
 	}
 	
 	return loadedPoints;

--- a/pointmatcher/IO.cpp
+++ b/pointmatcher/IO.cpp
@@ -34,6 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "IO.h"
+#include "IOFunctions.h"
 #include "InspectorsImpl.h"
 
 // For logging
@@ -53,6 +54,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef WIN32
 #define strtok_r strtok_s
 #endif // WIN32
+
+namespace PointMatcherSupport {
+	namespace {
+		const int one = 1;
+	}
+	const bool isBigEndian = *reinterpret_cast<const unsigned char*>(&one) == static_cast<unsigned char>(0);
+	const int oneBigEndian = isBigEndian ? 1 : 1 << 8 * (sizeof(int) - 1);
+}
 
 using namespace std;
 using namespace PointMatcherSupport;
@@ -872,12 +881,12 @@ PointMatcher<double>::DataPoints PointMatcherIO<double>::loadCSV(const std::stri
 
 //! Save a point cloud to a file, determine format from extension
 template<typename T>
-void PointMatcher<T>::DataPoints::save(const std::string& fileName) const
+void PointMatcher<T>::DataPoints::save(const std::string& fileName, bool binary) const
 {
 	const boost::filesystem::path path(fileName);
 	const string& ext(boost::filesystem::extension(path));
 	if (boost::iequals(ext, ".vtk"))
-		return PointMatcherIO<T>::saveVTK(*this, fileName);
+		return PointMatcherIO<T>::saveVTK(*this, fileName, binary);
 	else if (boost::iequals(ext, ".csv"))
 		return PointMatcherIO<T>::saveCSV(*this, fileName);
 	else if (boost::iequals(ext, ".ply"))
@@ -889,9 +898,9 @@ void PointMatcher<T>::DataPoints::save(const std::string& fileName) const
 }
 
 template
-void PointMatcher<float>::DataPoints::save(const std::string& fileName) const;
+void PointMatcher<float>::DataPoints::save(const std::string& fileName, bool binary) const;
 template
-void PointMatcher<double>::DataPoints::save(const std::string& fileName) const;
+void PointMatcher<double>::DataPoints::save(const std::string& fileName, bool binary) const;
 
 //! Save point cloud to a file as CSV
 template<typename T>
@@ -1243,21 +1252,22 @@ PointMatcherIO<double>::DataPoints PointMatcherIO<double>::loadVTK(const std::st
 
 //! Save point cloud to a file as VTK
 template<typename T>
-void PointMatcherIO<T>::saveVTK(const DataPoints& data, const std::string& fileName)
+void PointMatcherIO<T>::saveVTK(const DataPoints& data, const std::string& fileName, bool binary)
 {
 	typedef typename InspectorsImpl<T>::VTKFileInspector VTKInspector;
 	
 	Parametrizable::Parameters param;
 	boost::assign::insert(param) ("baseFileName", "");
+	boost::assign::insert(param) ("writeBinary", toParam(binary));
 	VTKInspector vtkInspector(param);
 	vtkInspector.dumpDataPoints(data, fileName);
 }
 
 
 template
-void PointMatcherIO<float>::saveVTK(const PointMatcherIO<float>::DataPoints& data, const std::string& fileName);
+void PointMatcherIO<float>::saveVTK(const PointMatcherIO<float>::DataPoints& data, const std::string& fileName, bool binary);
 template
-void PointMatcherIO<double>::saveVTK(const PointMatcher<double>::DataPoints& data, const std::string& fileName);
+void PointMatcherIO<double>::saveVTK(const PointMatcher<double>::DataPoints& data, const std::string& fileName, bool binary);
 
 //! @brief Load polygon file format (ply) file
 //! @param fileName a string containing the path and the file name

--- a/pointmatcher/IO.h
+++ b/pointmatcher/IO.h
@@ -198,7 +198,7 @@ struct PointMatcherIO
 	static DataPoints loadVTK(const std::string& fileName);
 	static DataPoints loadVTK(std::istream& is);
 
-	static void saveVTK(const DataPoints& data, const std::string& fileName);
+	static void saveVTK(const DataPoints& data, const std::string& fileName, bool binary = false);
 
 	// PLY
 	static DataPoints loadPLY(const std::string& fileName);

--- a/pointmatcher/IOFunctions.h
+++ b/pointmatcher/IOFunctions.h
@@ -1,0 +1,125 @@
+// kate: replace-tabs off; indent-width 4; indent-mode normal
+// vim: ts=4:sw=4:noexpandtab
+/*
+
+Copyright (c) 2010--2012,
+François Pomerleau and Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the authors at <f dot pomerleau at gmail dot com> and
+<stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef __POINTMATCHER_IOFUNCTIONS_H
+#define __POINTMATCHER_IOFUNCTIONS_H
+
+#include <iosfwd>
+
+namespace PointMatcherSupport
+{
+
+extern const bool isBigEndian; //!< true if platform is big endian
+extern const int oneBigEndian; //!< is always a big endian independent of the platforms endianness
+
+template <typename T>
+struct ConverterToAndFromBytes {
+	union {
+		T v;
+		char bytes[sizeof(T)];
+	};
+
+	ConverterToAndFromBytes(T v = static_cast<T>(0)) : v(v) {}
+
+	void swapBytes(){
+		ConverterToAndFromBytes tmp(this->v);
+		std::reverse_copy(tmp.bytes, tmp.bytes + sizeof(T), bytes);
+	}
+
+	friend std::ostream & operator << (std::ostream & out, const ConverterToAndFromBytes & c){
+		out.write(c.bytes, sizeof(T));
+		return out;
+	}
+	friend std::istream & operator >> (std::istream & in, ConverterToAndFromBytes & c){
+		in.read(c.bytes, sizeof(T));
+		return in;
+	}
+};
+
+template<typename Matrix>
+std::ostream & writeVtkData(bool writeBinary,const Matrix & data, std::ostream & out){
+	if(writeBinary){
+		typedef typename Matrix::Scalar TargetDataType;
+		for(int r = 0; r < data.rows(); r++){
+			for(int c = 0; c < data.cols(); c++){
+				ConverterToAndFromBytes<TargetDataType> converter(static_cast<TargetDataType>(data(r, c)));
+				if(!isBigEndian){
+					converter.swapBytes();
+				}
+				out << converter;
+			}
+		}
+	}else {
+		out << data;
+	}
+	return out;
+}
+
+template<typename DataType, typename MatrixRef>
+std::istream & readVtkData(bool readBinary, MatrixRef into, std::istream & in){
+	typedef typename MatrixRef::Scalar TargetDataType;
+	for(int r = 0; r < into.rows(); r++){
+		for(int c = 0; c < into.cols(); c++){
+			TargetDataType & dest = into(r, c);
+			if(readBinary){
+				ConverterToAndFromBytes<DataType> converter;
+				in >> converter;
+				if(!isBigEndian){
+					converter.swapBytes();
+				}
+				dest = converter.v;
+			}else {
+				in >> dest;
+			}
+		}
+	}
+	return in;
+}
+
+template<typename MatrixRef>
+std::istream & readVtkData(std::string dataType, bool readBinary, MatrixRef into, std::istream & in){
+	if(dataType == "float"){
+		return readVtkData<float>(readBinary, into, in);
+	} else if (dataType == "double") {
+		return readVtkData<double>(readBinary, into, in);
+	} else {
+		throw std::runtime_error(std::string("Unsupported data type : " + dataType + "! Expected 'float' or 'double'."));
+	}
+}
+
+
+} // PointMatcherSupport
+
+#endif // __POINTMATCHER_IOFUNCTIONS_H

--- a/pointmatcher/InspectorsImpl.h
+++ b/pointmatcher/InspectorsImpl.h
@@ -116,6 +116,7 @@ struct InspectorsImpl
 		const bool bDumpDataLinks;
 		const bool bDumpReading;
 		const bool bDumpReference;
+		const bool bWriteBinary;
 
 	public:
 		AbstractVTKInspector(const std::string& className, const ParametersDoc paramsDoc, const Parameters& params);
@@ -164,6 +165,7 @@ struct InspectorsImpl
 				( "dumpDataLinks", "dump data links at each iteration", "0" ) 
 				( "dumpReading", "dump the reading cloud at each iteration", "0" )
 				( "dumpReference", "dump the reference cloud at each iteration", "0" )
+				( "writeBinary", "write binary VTK files", "0" )
 			;
 		}
 		

--- a/pointmatcher/PointMatcher.h
+++ b/pointmatcher/PointMatcher.h
@@ -263,7 +263,7 @@ struct PointMatcher
 		unsigned getDescriptorDim() const;
 		unsigned getTimeDim() const;
 
-		void save(const std::string& fileName) const;
+		void save(const std::string& fileName, bool binary = false) const;
 		static DataPoints load(const std::string& fileName);
 		
 		void concatenate(const DataPoints& dp);

--- a/utest/ui/IO.cpp
+++ b/utest/ui/IO.cpp
@@ -369,11 +369,11 @@ public:
 		ptCloud.addDescriptor(descriptorName, PM::Matrix::Random(rows, nbPts));
 	}
 
-	virtual void loadSaveTest(const string& testFileName, bool plyFormat = false, const int nbPts = 10)
+	virtual void loadSaveTest(const string& testFileName, bool plyFormat = false, const int nbPts = 10, bool binary = false)
 	{
 		this->testFileName = testFileName;
 
-		if (plyFormat) {
+		if (plyFormat || binary) {
 			// make sure randam values generated for colors are within ply format range
 			int pointCount(ptCloud.features.cols());
 			int descRows(ptCloud.descriptors.rows());
@@ -392,7 +392,7 @@ public:
 			}
 		}
 
-		ptCloud.save(testFileName);
+		ptCloud.save(testFileName, binary);
 
 		ptCloudFromFile = DP::load(testFileName);
 
@@ -404,7 +404,7 @@ public:
 		EXPECT_TRUE(ptCloudFromFile.descriptorExists("eigVectors",9));
 		EXPECT_TRUE(ptCloudFromFile.getDescriptorViewByName("eigVectors").isApprox(ptCloud.getDescriptorViewByName("eigVectors")));
 		EXPECT_TRUE(ptCloudFromFile.descriptorExists("color",4));
-		if (plyFormat) {
+		if (plyFormat || binary) {
 			EXPECT_TRUE(((ptCloudFromFile.getDescriptorViewByName("color") * 255.0)).isApprox((ptCloud.getDescriptorViewByName("color") * 255.0), 1.0));
 		} else {
 			EXPECT_TRUE(ptCloudFromFile.getDescriptorViewByName("color").isApprox(ptCloud.getDescriptorViewByName("color")));
@@ -438,7 +438,17 @@ TEST_F(IOLoadSaveTest, VTK)
 
 	EXPECT_TRUE(ptCloudFromFile.descriptorExists("genericScalar",1));
 	EXPECT_TRUE(ptCloudFromFile.descriptorExists("genericVector",3));
+}
 
+TEST_F(IOLoadSaveTest, VTKBinary)
+{
+	ptCloud.addDescriptor("genericScalar", PM::Matrix::Random(1, nbPts));
+	ptCloud.addDescriptor("genericVector", PM::Matrix::Random(3, nbPts));
+
+	loadSaveTest(dataPath + "unit_test.bin.vtk", false, 10, true);
+
+	EXPECT_TRUE(ptCloudFromFile.descriptorExists("genericScalar",1));
+	EXPECT_TRUE(ptCloudFromFile.descriptorExists("genericVector",3));
 }
 
 TEST_F(IOLoadSaveTest, PLY)


### PR DESCRIPTION
NOT READY to MERGE. 

I just needed faster writing of point clouds and this quick and dirty implementation (not polished for merging yet) is already about 20 times faster than the ASCII version. And e.g. paraview is reading it way faster.

@pomerlef , do you think this is a useful extension (even though it is legacy VTK files anyway and reading the same files would not be supported without further effort) or would you rather switch to libvtk to read and write vtk files. Was there a good reason not to do that in the first place?
