### PR TITLE
Add getResidualError methods to ErrorMinimizer

### DIFF
--- a/pointmatcher/ErrorMinimizer.cpp
+++ b/pointmatcher/ErrorMinimizer.cpp
@@ -106,6 +106,14 @@ typename PointMatcher<T>::Matrix PointMatcher<T>::ErrorMinimizer::getCovariance(
   return Matrix::Zero(6,6);
 }
 
+//! If not redefined by child class, return max value for T
+template<typename T>
+T PointMatcher<T>::ErrorMinimizer::getResidualError(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches) const
+{
+  LOG_INFO_STREAM("ErrorMinimizer - warning, no specific method to compute residual was provided for the ErrorMinimizer used.");
+  return std::numeric_limits<T>::max();
+}
+
 //! Helper funtion doing the cross product in 3D and a pseudo cross product in 2D
 template<typename T>
 typename PointMatcher<T>::Matrix PointMatcher<T>::ErrorMinimizer::crossProduct(const Matrix& A, const Matrix& B)
@@ -256,6 +264,122 @@ typename PointMatcher<T>::ErrorMinimizer::ErrorElements& PointMatcher<T>::ErrorM
 	this->lastErrorElements.nbRejectedPoints = rejectedPointCount;
 
 	return this->lastErrorElements;
+}
+
+//! Helper function outputting pair of points from the reference and 
+//! the reading based on the matching matrix
+template<typename T>
+typename PointMatcher<T>::ErrorMinimizer::ErrorElements PointMatcher<T>::ErrorMinimizer::getMatchedPoints(
+		const DataPoints& requestedPts,
+		const DataPoints& sourcePts,
+		const Matches& matches, 
+		const OutlierWeights& outlierWeights) const
+{
+	typedef typename Matches::Ids Ids;
+	typedef typename Matches::Dists Dists;
+	
+	assert(matches.ids.rows() > 0);
+	assert(matches.ids.cols() > 0);
+	assert(matches.ids.cols() == requestedPts.features.cols()); //nbpts
+	assert(outlierWeights.rows() == matches.ids.rows());  // knn
+	
+	const int knn = outlierWeights.rows();
+	const int dimFeat = requestedPts.features.rows();
+	const int dimReqDesc = requestedPts.descriptors.rows();
+
+	// Count points with no weights
+	const int pointsCount = (outlierWeights.array() != 0.0).count();
+	if (pointsCount == 0)
+		throw ConvergenceError("ErrorMnimizer: no point to minimize");
+
+	Matrix keptFeat(dimFeat, pointsCount);
+	
+	Matrix keptDesc;
+	if(dimReqDesc > 0)
+		keptDesc = Matrix(dimReqDesc, pointsCount);
+
+	Matches keptMatches (Dists(1,pointsCount), Ids(1, pointsCount));
+	OutlierWeights keptWeights(1, pointsCount);
+
+	int j = 0;
+	int rejectedMatchCount = 0;
+	int rejectedPointCount = 0;
+	bool matchExist = false;
+	// T localWeightedPointUsedRatio = 0;
+	
+	for (int i = 0; i < requestedPts.features.cols(); ++i) //nb pts
+	{
+		matchExist = false;
+		for(int k = 0; k < knn; k++) // knn
+		{
+			if (outlierWeights(k,i) != 0.0)
+			{
+				if(dimReqDesc > 0)
+					keptDesc.col(j) = requestedPts.descriptors.col(i);
+				
+				keptFeat.col(j) = requestedPts.features.col(i);
+				keptMatches.ids(0, j) = matches.ids(k, i);
+				keptMatches.dists(0, j) = matches.dists(k, i);
+				keptWeights(0,j) = outlierWeights(k,i);
+				++j;
+				// localWeightedPointUsedRatio += outlierWeights(k,i);
+				matchExist = true;
+			}
+			else
+			{
+				rejectedMatchCount++;
+			}
+		}
+
+		if(matchExist == false)
+		{
+			rejectedPointCount++;
+		}
+	}
+
+	assert(j == pointsCount);
+
+	// T localPointUsedRatio = double(j)/double(knn*requestedPts.features.cols());
+	// localWeightedPointUsedRatio /= double(knn*requestedPts.features.cols());
+	
+	assert(dimFeat == sourcePts.features.rows());
+	const int dimSourDesc = sourcePts.descriptors.rows();
+	
+	Matrix associatedFeat(dimFeat, pointsCount);
+	Matrix associatedDesc;
+	if(dimSourDesc > 0)
+		associatedDesc = Matrix(dimSourDesc, pointsCount);
+
+	// Fetch matched points
+	for (int i = 0; i < pointsCount; ++i)
+	{
+		const int refIndex(keptMatches.ids(i));
+		associatedFeat.col(i) = sourcePts.features.block(0, refIndex, dimFeat, 1);
+		
+		if(dimSourDesc > 0)
+			associatedDesc.col(i) = sourcePts.descriptors.block(0, refIndex, dimSourDesc, 1);
+	}
+
+	ErrorElements localLastErrorElements;
+
+	localLastErrorElements.reading = DataPoints(
+		keptFeat, 
+		requestedPts.featureLabels,
+		keptDesc,
+		requestedPts.descriptorLabels
+	);
+	localLastErrorElements.reference = DataPoints(
+		associatedFeat,
+		sourcePts.featureLabels,
+		associatedDesc,
+		sourcePts.descriptorLabels
+	);
+	localLastErrorElements.weights = keptWeights;
+	localLastErrorElements.matches = keptMatches;
+	localLastErrorElements.nbRejectedMatches = rejectedMatchCount;
+	localLastErrorElements.nbRejectedPoints = rejectedPointCount;
+
+	return localLastErrorElements;
 }
 
 template struct PointMatcher<float>::ErrorMinimizer;

--- a/pointmatcher/ErrorMinimizersImpl.h
+++ b/pointmatcher/ErrorMinimizersImpl.h
@@ -73,6 +73,7 @@ struct ErrorMinimizersImpl
 		}
 		
 		virtual TransformationParameters compute(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches);
+		virtual T getResidualError(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches) const;
 		virtual T getOverlap() const;
 	};
 
@@ -84,6 +85,7 @@ struct ErrorMinimizersImpl
 		}
 		
 		virtual TransformationParameters compute(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches);
+		virtual T getResidualError(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches) const;
 		virtual T getOverlap() const;
 	};
 
@@ -105,6 +107,7 @@ struct ErrorMinimizersImpl
 		
 		PointToPlaneErrorMinimizer(const Parameters& params = Parameters());
 		virtual TransformationParameters compute(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches);
+		virtual T getResidualError(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches) const;
 		virtual T getOverlap() const;
 	};
 
@@ -127,6 +130,7 @@ struct ErrorMinimizersImpl
 
 		PointToPointWithCovErrorMinimizer(const Parameters& params = Parameters());
 		virtual TransformationParameters compute(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches);
+		virtual T getResidualError(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches) const;
 		virtual T getOverlap() const;
 		virtual Matrix getCovariance() const;
 		Matrix estimateCovariance(const DataPoints& reading, const DataPoints& reference, const Matches& matches, const OutlierWeights& outlierWeights, const TransformationParameters& transformation);
@@ -153,6 +157,7 @@ struct ErrorMinimizersImpl
 		
 		PointToPlaneWithCovErrorMinimizer(const Parameters& params = Parameters());
 		virtual TransformationParameters compute(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches);
+		virtual T getResidualError(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches) const;
 		virtual T getOverlap() const;
 		virtual Matrix getCovariance() const;
 		Matrix estimateCovariance(const DataPoints& reading, const DataPoints& reference, const Matches& matches, const OutlierWeights& outlierWeights, const TransformationParameters& transformation);

--- a/pointmatcher/PointMatcher.h
+++ b/pointmatcher/PointMatcher.h
@@ -532,6 +532,7 @@ struct PointMatcher
 		ErrorElements getErrorElements() const; //TODO: ensure that is return a usable value
 		virtual T getOverlap() const;
 		virtual Matrix getCovariance() const;
+		virtual T getResidualError(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches) const;
 		
 		//! Find the transformation that minimizes the error
 		virtual TransformationParameters compute(const DataPoints& filteredReading, const DataPoints& filteredReference, const OutlierWeights& outlierWeights, const Matches& matches) = 0;
@@ -541,6 +542,7 @@ struct PointMatcher
 		// helper functions
 		static Matrix crossProduct(const Matrix& A, const Matrix& B);//TODO: this might go in pointmatcher_support namespace
 		ErrorElements& getMatchedPoints(const DataPoints& reading, const DataPoints& reference, const Matches& matches, const OutlierWeights& outlierWeights);
+		ErrorElements  getMatchedPoints(const DataPoints& reading, const DataPoints& reference, const Matches& matches, const OutlierWeights& outlierWeights) const;
 		
 	protected:
 		T pointUsedRatio; //!< the ratio of how many points were used for error minimization


### PR DESCRIPTION
I added the getResidualError method to be able to assess the ICP result through the residual error. I'm sharing it here in case you're interested to add the functionality to the library.

Cheers!

----- Begin Commit Message -----
[error minimizer] Add getResidualError methods

getResidualError is a const method and makes use of getMatchedPoints, thus we
also add a const version of getMatchedPoints that does not change
ErrorMinimizer's lastErrorElements.

The residual error is computed in a separated function defined in an anonymous
namespace