### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/doc/Compilation.md
+++ b/doc/Compilation.md
@@ -191,7 +191,7 @@ make
 sudo make install
 ```
 
-#Having problems?
+# Having problems?
 Some dependencies changed and we don't keep track of all combinations possible. Before reporting a problem, make sure to include the versions you are using. You can run the bash script `./utest/listVersionsUbuntu.sh` and copy-paste its output when [reporting an issue on github](https://github.com/ethz-asl/libpointmatcher/issues). You may need to ensure that the file is executable:
 
 ```

--- a/doc/Datafilters.md
+++ b/doc/Datafilters.md
@@ -217,7 +217,7 @@ __Output descriptor:__ none
 __Sensor assumed to be at the origin:__ no  
 __Impact on the number of points:__ reduces number of points  
 
-##Shadow Point Filter <a name="shadowpointhead"></a>
+## Shadow Point Filter <a name="shadowpointhead"></a>
 
 ### Description
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
