### PR TITLE
Enable c++11 for libpointmatcher itself (addressing #202)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,45 @@ endif (POSIX_TIMERS AND NOT APPLE)
 #============================= end dependencies =================================
 
 
+#========================== libpointmatcher itself ==============================
+
+# Check the compiler version as we need full C++11 support.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+	# using Clang
+	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.3")
+		message(WARNING, "Your clang compiler has version ${CMAKE_CXX_COMPILER_VERSION}, while only version 3.3 or later is supported")
+	endif ()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+	# using AppleClang
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.1")
+		message(WARNING "Your XCode environment has version ${CMAKE_CXX_COMPILER_VERSION}, while only version 5.1 or later is supported")
+	endif()
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	# using GCC
+	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8.2")
+		message(WARNING, "Your g++ compiler has version ${CMAKE_CXX_COMPILER_VERSION}, while only version 4.8.2 or later is supported")
+	endif ()
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+	# using MSVC
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.0.23506")
+		message(WARNING "Your Microsoft Visual C++ compiler has version ${CMAKE_CXX_COMPILER_VERSION}, while only version MSVC 2015 Update 1+ or later is supported")
+	endif()
+endif ()
+
+# enable C++11 support.
+if (CMAKE_VERSION VERSION_LESS "3.1")
+	if (MSVC)
+		message(FATAL_ERROR, "CMake version 3.1 or later is required to compiler ${PROJECT_NAME} with Microsoft Visual C++")
+	endif ()
+	if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		set (CMAKE_CXX_FLAGS "-std=c++0x ${CMAKE_CXX_FLAGS}")
+	else ()
+		set (CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+	endif ()
+else ()
+	set (CMAKE_CXX_STANDARD 11)
+endif ()
+
 # SOURCE
 
 # Pointmatcher lib and install


### PR DESCRIPTION
This should not be merged before #203 , to stay friendly to client packages that do not have c++11 enabled.