### PR TITLE
Avoid using invalid matches

### DIFF
--- a/pointmatcher/OutlierFiltersImpl.cpp
+++ b/pointmatcher/OutlierFiltersImpl.cpp
@@ -36,6 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "OutlierFiltersImpl.h"
 #include "PointMatcherPrivate.h"
 #include "Functions.h"
+#include "MatchersImpl.h"
 
 #include <algorithm>
 #include <vector>
@@ -249,6 +250,8 @@ typename PointMatcher<T>::OutlierWeights OutlierFiltersImpl<T>::SurfaceNormalOut
 			for (int y = 0; y < w.rows(); ++y) // knn 
 			{
 				const int idRef = input.ids(y, x);
+
+				if(idRef == MatchersImpl<T>::NNS::InvalidIndex) continue;
 
 				const Vector normalRef = normalsReference.col(idRef).normalized();
 

--- a/pointmatcher/OutlierFiltersImpl.cpp
+++ b/pointmatcher/OutlierFiltersImpl.cpp
@@ -251,7 +251,10 @@ typename PointMatcher<T>::OutlierWeights OutlierFiltersImpl<T>::SurfaceNormalOut
 			{
 				const int idRef = input.ids(y, x);
 
-				if(idRef == MatchersImpl<T>::NNS::InvalidIndex) continue;
+				if(idRef == MatchersImpl<T>::NNS::InvalidIndex) {
+					w(y, x) = 0;
+					continue;
+				}
 
 				const Vector normalRef = normalsReference.col(idRef).normalized();
 


### PR DESCRIPTION
Since https://github.com/ethz-asl/libnabo/pull/79 the invalid index is no longer `0`. 

This revealed that libpointmatcher was actually using (IMO) invalid matches as if they were matches with the first entry. (see #228 ).

Currently this is only a start fixing this: It affects more than just this line. And my fix is probably not the best.

@bochen87, if you are still motivated to help: could you test this branch together with libnabo master?

