### PR TITLE
Changed pass by const value to pass by const reference to remove the extra copy.

### DIFF
--- a/pointmatcher/ErrorMinimizer.cpp
+++ b/pointmatcher/ErrorMinimizer.cpp
@@ -56,7 +56,7 @@ PointMatcher<T>::ErrorMinimizer::ErrorElements::ErrorElements():
 
 //! Constructor from existing data. This will align the data.
 template<typename T>
-PointMatcher<T>::ErrorMinimizer::ErrorElements::ErrorElements(const DataPoints& requestedPts, const DataPoints sourcePts, const OutlierWeights outlierWeights, const Matches matches)
+PointMatcher<T>::ErrorMinimizer::ErrorElements::ErrorElements(const DataPoints& requestedPts, const DataPoints& sourcePts, const OutlierWeights& outlierWeights, const Matches& matches)
 {
 	typedef typename Matches::Ids Ids;
 	typedef typename Matches::Dists Dists;

--- a/pointmatcher/PointMatcher.h
+++ b/pointmatcher/PointMatcher.h
@@ -533,7 +533,7 @@ struct PointMatcher
 			T weightedPointUsedRatio;//!< the ratio of how many points were used (with weight) for error minimization
 
 			ErrorElements();
-			ErrorElements(const DataPoints& requestedPts, const DataPoints sourcePts, const OutlierWeights outlierWeights, const Matches matches);
+			ErrorElements(const DataPoints& requestedPts, const DataPoints& sourcePts, const OutlierWeights& outlierWeights, const Matches& matches);
 		};
 		
 		ErrorMinimizer();


### PR DESCRIPTION
When making these error minimizer objects a copy of the source data points is made.  If the number of source points is large and then making this copy can be really expensive.  Since these are passed by const value they can be passed by const reference to remove the copy.