### PR TITLE
[WIP] manual data and descriptors example

### DIFF
--- a/doc/Datafilters.md
+++ b/doc/Datafilters.md
@@ -61,8 +61,11 @@ The following examples are drawn from the apartment dataset available for [downl
 Points can be excluded from a rectangular bounding region by using this filter.  The box dimensions are specified by defining the maximum and minimum coordinate values in the x,y,z directions.
 
 __Required descriptors:__ none
+
 __Output descriptor:__ none
+
 __Sensor assumed to be at the origin:__ no
+
 __Impact on the number of points:__ reduces number of points
 
 
@@ -95,9 +98,14 @@ A number of filters are used to reduce the number of points in a cloud by random
 
 Points are only considered for rejection if they exceed a density threshold, otherwise they are preserved.  The single parameter of this filter sets the maximum density that should be obtained in the output point cloud.  Points are randomly rejected such that this maximum density is obtained as closely as possible.
 
-__Required descriptors:__ `densities` (see SurfaceNormalDataPointsFilter and SamplingSurfaceNormalDataPointsFilter)
+__Required descriptors:__
+
+- `densities` (see SurfaceNormalDataPointsFilter and SamplingSurfaceNormalDataPointsFilter)
+
 __Output descriptor:__ none
+
 __Sensor assumed to be at the origin:__ no
+
 __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -116,8 +124,11 @@ In the following example we observe the effect of the maximum density filter on 
 These filters remove points which lie beyond a threshold distance from the coordinate center.  Points are kept if their distance from the center **greater than** the threshold.  The distance threshold can be defined on the x,y, and z axes or can be a radial distance from the center.
 
 __Required descriptors:__ none
+
 __Output descriptor:__ none
+
 __Sensor assumed to be at the origin:__ no
+
 __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -137,8 +148,11 @@ In the following example, a maximum distance threshold of 1m is applied radially
 These filters remove points which lie beyond a threshold distance from the coordinate center.  Points are kept if their distance from the center **smaller than** the threshold.  The distance threshold can be defined on the x,y, and z axes or can be a radial distance from the center.
 
 __Required descriptors:__ none
+
 __Output descriptor:__ none
+
 __Sensor assumed to be at the origin:__ no
+
 __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -152,8 +166,11 @@ Conditional subsampling. This filter reduces the size of the point cloud by rand
 
 
 __Required descriptors:__ none
+
 __Output descriptor:__ none
+
 __Sensor assumed to be at the origin:__ no
+
 __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -170,8 +187,11 @@ No example available.
 Points are filtered according to where they lie on a distribution of their positions along a given axis.  The entire distance range is divided into quantiles which lie between 0 and 1.  One can specify the distance quantile above which points are rejected by the filter.
 
 __Required descriptors:__ none
+
 __Output descriptor:__ none
+
 __Sensor assumed to be at the origin:__ no
+
 __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -192,8 +212,11 @@ In the following example, maximum quantile filtering is performed over the x-axi
 This filter behaves similarly to the [Maximum Point Count Filter](#maxpointcounthead) but does not enforce a maximum point constraint.  Instead points are kept by the filter with a fixed probability.
 
 __Required descriptors:__ none
+
 __Output descriptor:__ none
+
 __Sensor assumed to be at the origin:__ no
+
 __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -213,8 +236,11 @@ In the following sample, points are kept with a probability of 0.1.  Therefore t
 Due to errors in the capture process point clouds may contain points with invalid coordinates.  This filter can be applied to remove points which contain a NaN coordinate, thus producing a "clean" dataset.
 
 __Required descriptors:__ none
+
 __Output descriptor:__ none
+
 __Sensor assumed to be at the origin:__ no
+
 __Impact on the number of points:__ reduces number of points
 
 Note: when there are descriptors present, both the features (input cloud positions) and the descriptors are checked.  For example, if you have a `"normals"` descriptor, for index `i` both the position and the normal must be non-NaN to make it past this filter.  If the position was not NaN, but the normal had a NaN, both the position and the normal are filtered out.  The same is true for more generally for all descriptors.
@@ -225,9 +251,14 @@ Note: when there are descriptors present, both the features (input cloud positio
 
 Shadow points are noisy points usually located at point cloud edge discontinuities.
 
-__Required descriptors:__  `normals`  (see SurfaceNormalDataPointsFilter)
+__Required descriptors:__
+
+- `normals`  (see SurfaceNormalDataPointsFilter)
+
 __Output descriptor:__ none
+
 __Sensor assumed to be at the origin:__ no
+
 __Impact on the number of points:__ reduces number of points
 
 *IMPORTANT:* The surface normal descriptors are required in the input point cloud.
@@ -243,8 +274,13 @@ There are two options as to how to represent the distribution of points in a vox
 This filter also provides two methods for sub-sampling descriptors.  In the first, all descriptors within a voxel are averaged while in the second, only the first descriptor from a voxel is kept.
 
 __Required descriptors:__  none
-__Output descriptor:__ outputs average or single descriptor per voxel if the input cloud contains descriptors
+
+__Output descriptor:__
+
+- outputs average or single descriptor per voxel if the input cloud contains descriptors
+
 __Sensor assumed to be at the origin:__ no
+
 __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -272,8 +308,13 @@ As opposed to the previous filters, the following does not yield a sub-sample of
 The returned direction vector is a vector connecting the point and the sensor, whose positions can be specified in the filter parameters.
 
 __Required descriptors:__   none
-__Output descriptor:__ `observationDirections`
+
+__Output descriptor:__
+
+- `observationDirections`
+
 __Sensor assumed to be at the origin:__ yes
+
 __Impact on the number of points:__ none
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -297,12 +338,16 @@ The surface normal to each point is estimated by finding a number of neighboring
 Remark that that given a surface, the normal vector can point in two possible directions.  Following the apartment example used herein throughout, the normal vector of a wall can point inside towards the room, or outside the apartment.  To align all normal vectors in the same direction, the [orient normals filter](#orientnormalshead) can be used.
 
 __Required descriptors:__ none
+
 __Output descriptor:__
-`normals`
-`densities`
-`eigValues`
-`eigVectors`
+
+- `normals`
+- `densities`
+- `eigValues`
+- `eigVectors`
+
 __Sensor assumed to be at the origin:__ no
+
 __Impact on the number of points:__ none
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -330,10 +375,14 @@ In this example, we again use a local point cloud of the apartment. You may reco
 As explained previously, neighboring surface normal vectors obtained from the surface normals filter, do not have the same orientation.  This filter enforces this constraint and reorients vectors from the same surface in a consistent direction.  Vectors are reoriented to either point towards the center (inwards), or away from the center (outwards).
 
 __Required descriptors:__
-  `observationDirections` (see ObservationDirectionDataPointsFilter)
-  `normals` (see SurfaceNormalDataPointsFilter, SamplingSurfaceNormalDataPointsFilter)
+
+- `observationDirections` (see ObservationDirectionDataPointsFilter)
+- `normals` (see SurfaceNormalDataPointsFilter, SamplingSurfaceNormalDataPointsFilter)
+
 __Output descriptor:__ none
+
 __Sensor assumed to be at the origin:__ yes
+
 __Impact on the number of points:__ none
 
 
@@ -357,12 +406,16 @@ The same input section is used as for extracting the surface normals in the prev
 The above filters extract surface normals at every point in the point cloud.  In point clouds representing planar surfaces however, a significant redundant information is contained in adjacent normal vectors.  This filter attempts to both reduce the number of points within a point cloud and the number of different normal vectors.  The first is achieved by performing either random sub-sampling as seen previously, or by using one point per box (bin sub-sampling).  The latter is achieved by recursively decomposing the point-cloud space into boxes until each box contains at most knn points.  A single normal vector is computed from the knn points in each box.
 
 __Required descriptors:__  none
+
 __Output descriptor:__
-`normals`
-`densities`
-`eigValues`
-`eigVectors`
+
+- `normals`
+- `densities`
+- `eigValues`
+- `eigVectors`
+
 __Sensor assumed to be at the origin:__ yes
+
 __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -397,8 +450,13 @@ We reuse the same apartment section to illustrate the sampling of normal vectors
 This filter is used to augment points with an estimation of position uncertainty based on sensor specifications.  So far the [SICK LMS](http://www.sick.com/group/EN/home/products/product_news/laser_measurement_systems/Pages/lms100.aspx), [Hokuyo](http://www.hokuyo-aut.jp/02sensor/index.html#scanner) URG-04LX and UTM-30LX, as well as the Microsoft [Kinect](http://www.microsoft.com/en-us/kinectforwindows/) and Asus [Xtion](http://www.asus.com/Multimedia/Xtion_PRO_LIVE/) sensors are supported.  The uncertainty or noise radius is represented in meters, and can be adjusted by varying a gain parameter which amplifies predefined uncertainty levels.
 
 __Required descriptors:__  none
-__Output descriptor:__ `simpleSensorNoise`
+
+__Output descriptor:__
+
+- `simpleSensorNoise`
+
 __Sensor assumed to be at the origin:__ yes
+
 __Impact on the number of points:__ none
 
 |Parameter  |Description  |Default value    |Allowable range|

--- a/doc/Datafilters.md
+++ b/doc/Datafilters.md
@@ -60,13 +60,10 @@ The following examples are drawn from the apartment dataset available for [downl
 ### Description
 Points can be excluded from a rectangular bounding region by using this filter.  The box dimensions are specified by defining the maximum and minimum coordinate values in the x,y,z directions.
 
-__Required descriptors:__ none
-
-__Output descriptor:__ none
-
-__Sensor assumed to be at the origin:__ no
-
-__Impact on the number of points:__ reduces number of points
+- __Required descriptors:__ none
+- __Output descriptor:__ none
+- __Sensor assumed to be at the origin:__ no
+- __Impact on the number of points:__ reduces number of points
 
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -98,15 +95,11 @@ A number of filters are used to reduce the number of points in a cloud by random
 
 Points are only considered for rejection if they exceed a density threshold, otherwise they are preserved.  The single parameter of this filter sets the maximum density that should be obtained in the output point cloud.  Points are randomly rejected such that this maximum density is obtained as closely as possible.
 
-__Required descriptors:__
-
-- `densities` (see SurfaceNormalDataPointsFilter and SamplingSurfaceNormalDataPointsFilter)
-
-__Output descriptor:__ none
-
-__Sensor assumed to be at the origin:__ no
-
-__Impact on the number of points:__ reduces number of points
+- __Required descriptors:__
+    - `densities` (see SurfaceNormalDataPointsFilter and SamplingSurfaceNormalDataPointsFilter)
+- __Output descriptor:__ none
+- __Sensor assumed to be at the origin:__ no
+- __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -123,13 +116,10 @@ In the following example we observe the effect of the maximum density filter on 
 ### Description
 These filters remove points which lie beyond a threshold distance from the coordinate center.  Points are kept if their distance from the center **greater than** the threshold.  The distance threshold can be defined on the x,y, and z axes or can be a radial distance from the center.
 
-__Required descriptors:__ none
-
-__Output descriptor:__ none
-
-__Sensor assumed to be at the origin:__ no
-
-__Impact on the number of points:__ reduces number of points
+- __Required descriptors:__ none
+- __Output descriptor:__ none
+- __Sensor assumed to be at the origin:__ no
+- __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -147,13 +137,10 @@ In the following example, a maximum distance threshold of 1m is applied radially
 ### Description
 These filters remove points which lie beyond a threshold distance from the coordinate center.  Points are kept if their distance from the center **smaller than** the threshold.  The distance threshold can be defined on the x,y, and z axes or can be a radial distance from the center.
 
-__Required descriptors:__ none
-
-__Output descriptor:__ none
-
-__Sensor assumed to be at the origin:__ no
-
-__Impact on the number of points:__ reduces number of points
+- __Required descriptors:__ none
+- __Output descriptor:__ none
+- __Sensor assumed to be at the origin:__ no
+- __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -165,13 +152,10 @@ __Impact on the number of points:__ reduces number of points
 Conditional subsampling. This filter reduces the size of the point cloud by randomly dropping points if their number is above `maxCount`. The resulting point cloud while have `maxCount` number of point. the Based on:  Registration and integration of multiple range images for 3-D model construction. Masuda, T. and Sakaue, K. and Yokoya, N. In Pattern Recognition, 1996., Proceedings of the 13th International Conference on. 879--883. 1996.
 
 
-__Required descriptors:__ none
-
-__Output descriptor:__ none
-
-__Sensor assumed to be at the origin:__ no
-
-__Impact on the number of points:__ reduces number of points
+- __Required descriptors:__ none
+- __Output descriptor:__ none
+- __Sensor assumed to be at the origin:__ no
+- __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -186,13 +170,10 @@ No example available.
 ### Description
 Points are filtered according to where they lie on a distribution of their positions along a given axis.  The entire distance range is divided into quantiles which lie between 0 and 1.  One can specify the distance quantile above which points are rejected by the filter.
 
-__Required descriptors:__ none
-
-__Output descriptor:__ none
-
-__Sensor assumed to be at the origin:__ no
-
-__Impact on the number of points:__ reduces number of points
+- __Required descriptors:__ none
+- __Output descriptor:__ none
+- __Sensor assumed to be at the origin:__ no
+- __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -211,13 +192,10 @@ In the following example, maximum quantile filtering is performed over the x-axi
 ### Description
 This filter behaves similarly to the [Maximum Point Count Filter](#maxpointcounthead) but does not enforce a maximum point constraint.  Instead points are kept by the filter with a fixed probability.
 
-__Required descriptors:__ none
-
-__Output descriptor:__ none
-
-__Sensor assumed to be at the origin:__ no
-
-__Impact on the number of points:__ reduces number of points
+- __Required descriptors:__ none
+- __Output descriptor:__ none
+- __Sensor assumed to be at the origin:__ no
+- __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -235,13 +213,10 @@ In the following sample, points are kept with a probability of 0.1.  Therefore t
 ### Description
 Due to errors in the capture process point clouds may contain points with invalid coordinates.  This filter can be applied to remove points which contain a NaN coordinate, thus producing a "clean" dataset.
 
-__Required descriptors:__ none
-
-__Output descriptor:__ none
-
-__Sensor assumed to be at the origin:__ no
-
-__Impact on the number of points:__ reduces number of points
+- __Required descriptors:__ none
+- __Output descriptor:__ none
+- __Sensor assumed to be at the origin:__ no
+- __Impact on the number of points:__ reduces number of points
 
 Note: when there are descriptors present, both the features (input cloud positions) and the descriptors are checked.  For example, if you have a `"normals"` descriptor, for index `i` both the position and the normal must be non-NaN to make it past this filter.  If the position was not NaN, but the normal had a NaN, both the position and the normal are filtered out.  The same is true for more generally for all descriptors.
 
@@ -251,15 +226,11 @@ Note: when there are descriptors present, both the features (input cloud positio
 
 Shadow points are noisy points usually located at point cloud edge discontinuities.
 
-__Required descriptors:__
-
-- `normals`  (see SurfaceNormalDataPointsFilter)
-
-__Output descriptor:__ none
-
-__Sensor assumed to be at the origin:__ no
-
-__Impact on the number of points:__ reduces number of points
+- __Required descriptors:__
+    - `normals`  (see SurfaceNormalDataPointsFilter)
+- __Output descriptor:__ none
+- __Sensor assumed to be at the origin:__ no
+- __Impact on the number of points:__ reduces number of points
 
 *IMPORTANT:* The surface normal descriptors are required in the input point cloud.
 
@@ -273,15 +244,11 @@ There are two options as to how to represent the distribution of points in a vox
 
 This filter also provides two methods for sub-sampling descriptors.  In the first, all descriptors within a voxel are averaged while in the second, only the first descriptor from a voxel is kept.
 
-__Required descriptors:__  none
-
-__Output descriptor:__
-
-- outputs average or single descriptor per voxel if the input cloud contains descriptors
-
-__Sensor assumed to be at the origin:__ no
-
-__Impact on the number of points:__ reduces number of points
+- __Required descriptors:__  none
+- __Output descriptor:__
+    - outputs average or single descriptor per voxel if the input cloud contains descriptors
+- __Sensor assumed to be at the origin:__ no
+- __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -307,15 +274,11 @@ As opposed to the previous filters, the following does not yield a sub-sample of
 
 The returned direction vector is a vector connecting the point and the sensor, whose positions can be specified in the filter parameters.
 
-__Required descriptors:__   none
-
-__Output descriptor:__
-
-- `observationDirections`
-
-__Sensor assumed to be at the origin:__ yes
-
-__Impact on the number of points:__ none
+- __Required descriptors:__   none
+- __Output descriptor:__
+    - `observationDirections`
+- __Sensor assumed to be at the origin:__ yes
+- __Impact on the number of points:__ none
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -337,18 +300,14 @@ The surface normal to each point is estimated by finding a number of neighboring
 
 Remark that that given a surface, the normal vector can point in two possible directions.  Following the apartment example used herein throughout, the normal vector of a wall can point inside towards the room, or outside the apartment.  To align all normal vectors in the same direction, the [orient normals filter](#orientnormalshead) can be used.
 
-__Required descriptors:__ none
-
-__Output descriptor:__
-
-- `normals`
-- `densities`
-- `eigValues`
-- `eigVectors`
-
-__Sensor assumed to be at the origin:__ no
-
-__Impact on the number of points:__ none
+- __Required descriptors:__ none
+- __Output descriptor:__
+    - `normals`
+    - `densities`
+    - `eigValues`
+    - `eigVectors`
+- __Sensor assumed to be at the origin:__ no
+- __Impact on the number of points:__ none
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -374,16 +333,12 @@ In this example, we again use a local point cloud of the apartment. You may reco
 ### Description
 As explained previously, neighboring surface normal vectors obtained from the surface normals filter, do not have the same orientation.  This filter enforces this constraint and reorients vectors from the same surface in a consistent direction.  Vectors are reoriented to either point towards the center (inwards), or away from the center (outwards).
 
-__Required descriptors:__
-
-- `observationDirections` (see ObservationDirectionDataPointsFilter)
-- `normals` (see SurfaceNormalDataPointsFilter, SamplingSurfaceNormalDataPointsFilter)
-
-__Output descriptor:__ none
-
-__Sensor assumed to be at the origin:__ yes
-
-__Impact on the number of points:__ none
+- __Required descriptors:__
+    - `observationDirections` (see ObservationDirectionDataPointsFilter)
+    - `normals` (see SurfaceNormalDataPointsFilter, SamplingSurfaceNormalDataPointsFilter)
+- __Output descriptor:__ none
+- __Sensor assumed to be at the origin:__ yes
+- __Impact on the number of points:__ none
 
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -405,18 +360,14 @@ The same input section is used as for extracting the surface normals in the prev
 ### Description
 The above filters extract surface normals at every point in the point cloud.  In point clouds representing planar surfaces however, a significant redundant information is contained in adjacent normal vectors.  This filter attempts to both reduce the number of points within a point cloud and the number of different normal vectors.  The first is achieved by performing either random sub-sampling as seen previously, or by using one point per box (bin sub-sampling).  The latter is achieved by recursively decomposing the point-cloud space into boxes until each box contains at most knn points.  A single normal vector is computed from the knn points in each box.
 
-__Required descriptors:__  none
-
-__Output descriptor:__
-
-- `normals`
-- `densities`
-- `eigValues`
-- `eigVectors`
-
-__Sensor assumed to be at the origin:__ yes
-
-__Impact on the number of points:__ reduces number of points
+- __Required descriptors:__  none
+- __Output descriptor:__
+    - `normals`
+    - `densities`
+    - `eigValues`
+    - `eigVectors`
+- __Sensor assumed to be at the origin:__ yes
+- __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -449,15 +400,11 @@ We reuse the same apartment section to illustrate the sampling of normal vectors
 ### Description
 This filter is used to augment points with an estimation of position uncertainty based on sensor specifications.  So far the [SICK LMS](http://www.sick.com/group/EN/home/products/product_news/laser_measurement_systems/Pages/lms100.aspx), [Hokuyo](http://www.hokuyo-aut.jp/02sensor/index.html#scanner) URG-04LX and UTM-30LX, as well as the Microsoft [Kinect](http://www.microsoft.com/en-us/kinectforwindows/) and Asus [Xtion](http://www.asus.com/Multimedia/Xtion_PRO_LIVE/) sensors are supported.  The uncertainty or noise radius is represented in meters, and can be adjusted by varying a gain parameter which amplifies predefined uncertainty levels.
 
-__Required descriptors:__  none
-
-__Output descriptor:__
-
-- `simpleSensorNoise`
-
-__Sensor assumed to be at the origin:__ yes
-
-__Impact on the number of points:__ none
+- __Required descriptors:__  none
+- __Output descriptor:__
+    - `simpleSensorNoise`
+- __Sensor assumed to be at the origin:__ yes
+- __Impact on the number of points:__ none
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|

--- a/doc/Datafilters.md
+++ b/doc/Datafilters.md
@@ -8,7 +8,7 @@ In this section, the various filters which can be applied to the reading and ref
 As a reminder, *datapoint filters* can have several purposes:
 
 * Removing noisy points which render the alignment of point clouds difficult.
-* Removing redundant points so as to speed up alignment 
+* Removing redundant points so as to speed up alignment
 * Adding descriptive information to the points such as a surface normal vector, or the direction from the point to the sensor.
 
 Note that *datapoint filters* differ from *outlier filters* which appear further down the ICP chain and have a different purpose.
@@ -37,7 +37,7 @@ Note that *datapoint filters* differ from *outlier filters* which appear further
 
 10. [Voxel Grid Filter](#voxelgridhead)
 
-### Descriptor Augmenting 
+### Descriptor Augmenting
 1. [Observation Direction Filter](#obsdirectionhead)
 
 2. [Surface Normal Filter](#surfacenormalhead)
@@ -58,12 +58,12 @@ The following examples are drawn from the apartment dataset available for [downl
 
 ## Bounding Box Filter <a name="boundingboxhead"></a>
 ### Description
-Points can be excluded from a rectangular bounding region by using this filter.  The box dimensions are specified by defining the maximum and minimum coordinate values in the x,y,z directions. 
+Points can be excluded from a rectangular bounding region by using this filter.  The box dimensions are specified by defining the maximum and minimum coordinate values in the x,y,z directions.
 
-__Required descriptors:__ none   
-__Output descriptor:__ none  
-__Sensor assumed to be at the origin:__ no  
-__Impact on the number of points:__ reduces number of points  
+__Required descriptors:__ none
+__Output descriptor:__ none
+__Sensor assumed to be at the origin:__ no
+__Impact on the number of points:__ reduces number of points
 
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -93,32 +93,32 @@ Note that only points **outside** the bounding box are removed by the filter by 
 ### Description
 A number of filters are used to reduce the number of points in a cloud by randomly sub-sampling or randomly rejecting a set of points.  Points in regions of high density often contain redundant information, and the ICP algorithm could be performed more efficiently with a smaller number of points.  This filter is thus used to homogenize the density of a point cloud by rejecting a sub-sample of points in high-density regions.
 
-Points are only considered for rejection if they exceed a density threshold, otherwise they are preserved.  The single parameter of this filter sets the maximum density that should be obtained in the output point cloud.  Points are randomly rejected such that this maximum density is obtained as closely as possible.  
+Points are only considered for rejection if they exceed a density threshold, otherwise they are preserved.  The single parameter of this filter sets the maximum density that should be obtained in the output point cloud.  Points are randomly rejected such that this maximum density is obtained as closely as possible.
 
-__Required descriptors:__ `densities` (see SurfaceNormalDataPointsFilter and SamplingSurfaceNormalDataPointsFilter)   
-__Output descriptor:__ none  
-__Sensor assumed to be at the origin:__ no  
-__Impact on the number of points:__ reduces number of points  
+__Required descriptors:__ `densities` (see SurfaceNormalDataPointsFilter and SamplingSurfaceNormalDataPointsFilter)
+__Output descriptor:__ none
+__Sensor assumed to be at the origin:__ no
+__Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
-|maxDensity |The desired maximum density of points in *points/m^3 (for 3D), points/m^2 (for 2D)* | 10 | min: 0.0000001, max: inf|   
+|maxDensity |The desired maximum density of points in *points/m^3 (for 3D), points/m^2 (for 2D)* | 10 | min: 0.0000001, max: inf|
 
 ### Example
 In the following example we observe the effect of the maximum density filter on the apartment point cloud.  Sub-sampling occurs mostly in high density regions, which colored in red in the image below.  The result is an image with lower density overall with the low density regions in blue being preserved.
 
 |Figure: Max density filter applied to subsection of the apartment dataset.  On the <br>original data, low density regions are blue and high density regions are red.  The <br>sampled points are overlaid in white.   | Parameters used |
-|---|:---| 
+|---|:---|
 |![max density before](images/appt_0_maxdens.png "Max density filter applied to subsection of the apartment dataset.  On the original data, low density regions are blue and high density regions are red.  The sampled points are overlaid in white.") | maxDensity: 50000 |
 
 ## Maximum Distance Filter <a name="maxdistancehead"></a>
 ### Description
 These filters remove points which lie beyond a threshold distance from the coordinate center.  Points are kept if their distance from the center **greater than** the threshold.  The distance threshold can be defined on the x,y, and z axes or can be a radial distance from the center.
 
-__Required descriptors:__ none   
-__Output descriptor:__ none  
-__Sensor assumed to be at the origin:__ no  
-__Impact on the number of points:__ reduces number of points  
+__Required descriptors:__ none
+__Output descriptor:__ none
+__Sensor assumed to be at the origin:__ no
+__Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -126,7 +126,7 @@ __Impact on the number of points:__ reduces number of points
 |maxDist |Distance threshold (in m) beyond which points are rejected | 1.0 | min: -inf, max: inf|
 
 ### Example
-In the following example, a maximum distance threshold of 1m is applied radially by setting the dimension parameter to -1.  As shown on the image below, points which lie within a sphere of radius 1m centered at the origin are selected by the filter and are displayed in white.  All other points are rejected by the filter.  Were a maximum distance filter to be replaced by an equivalent minimum distance filter, only points outside the sphere would be selected. 
+In the following example, a maximum distance threshold of 1m is applied radially by setting the dimension parameter to -1.  As shown on the image below, points which lie within a sphere of radius 1m centered at the origin are selected by the filter and are displayed in white.  All other points are rejected by the filter.  Were a maximum distance filter to be replaced by an equivalent minimum distance filter, only points outside the sphere would be selected.
 
 |Figure: Max density filter applied to subsection of the apartment dataset.  On the <br>original data, low density regions are blue and high density regions are red.  The <br>sampled points are overlaid in white.   | Parameters used |
 |---|:---|
@@ -136,10 +136,10 @@ In the following example, a maximum distance threshold of 1m is applied radially
 ### Description
 These filters remove points which lie beyond a threshold distance from the coordinate center.  Points are kept if their distance from the center **smaller than** the threshold.  The distance threshold can be defined on the x,y, and z axes or can be a radial distance from the center.
 
-__Required descriptors:__ none   
-__Output descriptor:__ none  
-__Sensor assumed to be at the origin:__ no  
-__Impact on the number of points:__ reduces number of points  
+__Required descriptors:__ none
+__Output descriptor:__ none
+__Sensor assumed to be at the origin:__ no
+__Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -151,10 +151,10 @@ __Impact on the number of points:__ reduces number of points
 Conditional subsampling. This filter reduces the size of the point cloud by randomly dropping points if their number is above `maxCount`. The resulting point cloud while have `maxCount` number of point. the Based on:  Registration and integration of multiple range images for 3-D model construction. Masuda, T. and Sakaue, K. and Yokoya, N. In Pattern Recognition, 1996., Proceedings of the 13th International Conference on. 879--883. 1996.
 
 
-__Required descriptors:__ none   
-__Output descriptor:__ none  
-__Sensor assumed to be at the origin:__ no  
-__Impact on the number of points:__ reduces number of points  
+__Required descriptors:__ none
+__Output descriptor:__ none
+__Sensor assumed to be at the origin:__ no
+__Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -169,21 +169,21 @@ No example available.
 ### Description
 Points are filtered according to where they lie on a distribution of their positions along a given axis.  The entire distance range is divided into quantiles which lie between 0 and 1.  One can specify the distance quantile above which points are rejected by the filter.
 
-__Required descriptors:__ none   
-__Output descriptor:__ none  
-__Sensor assumed to be at the origin:__ no  
-__Impact on the number of points:__ reduces number of points  
+__Required descriptors:__ none
+__Output descriptor:__ none
+__Sensor assumed to be at the origin:__ no
+__Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
 |dim        | Dimension over which the distance (from the center) is thresholded | 0 | x:0 y:1 z:2 |
-|ratio |Quantile threshold.  Points whose distance exceed this threshold are rejected by the filter | 0.5 | min: 0.0000001, max: 0.9999999 | 
+|ratio |Quantile threshold.  Points whose distance exceed this threshold are rejected by the filter | 0.5 | min: 0.0000001, max: 0.9999999 |
 
 ### Example
 In the following example, maximum quantile filtering is performed over the x-axis with a quantile threshold of 0.5.  Therefore, points which have an x-value which exceeds the 50% quantile are rejected.  The output of the filter is displayed in white and overlaid with the input point cloud in the image below.  A sampling region centered at the origin and extending in both directions of the x-axis is clearly visible.
 
 |Figure: Maximum quantile on axis filter in the x-direction with a maximum quantile <br>of 0.5.   | Parameters used |
-|---|:---|  
+|---|:---|
 |![max quant after](images/max_quant.png "After applying maximum quantile on axis filter in the x-direction with a maximum quantile of 0.5") | dim : 0 <br> ratio : 0.5 |
 
 ## Random Sampling Filter <a name="randomsamplinghead"></a>
@@ -191,10 +191,10 @@ In the following example, maximum quantile filtering is performed over the x-axi
 ### Description
 This filter behaves similarly to the [Maximum Point Count Filter](#maxpointcounthead) but does not enforce a maximum point constraint.  Instead points are kept by the filter with a fixed probability.
 
-__Required descriptors:__ none   
-__Output descriptor:__ none  
-__Sensor assumed to be at the origin:__ no  
-__Impact on the number of points:__ reduces number of points  
+__Required descriptors:__ none
+__Output descriptor:__ none
+__Sensor assumed to be at the origin:__ no
+__Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -204,7 +204,7 @@ __Impact on the number of points:__ reduces number of points
 In the following sample, points are kept with a probability of 0.1.  Therefore the total number of points in the output point cloud is approximately 10 times less than the number of points in the input point cloud and the density is decreased overall.
 
 |Figure:  After applying the random sampling filter with a probability of 0.1. <br> The original data is shown in black and the sampled points in white.   | Parameters used |
-|---|:---|  
+|---|:---|
 |![rand after](images/appt_0_rand.png "After applying the random sampling filter with a probability of 0.1") | prob : 0.1 |
 
 ## Remove NaN Filter <a name="removenanhead"></a>
@@ -212,10 +212,12 @@ In the following sample, points are kept with a probability of 0.1.  Therefore t
 ### Description
 Due to errors in the capture process point clouds may contain points with invalid coordinates.  This filter can be applied to remove points which contain a NaN coordinate, thus producing a "clean" dataset.
 
-__Required descriptors:__ none   
-__Output descriptor:__ none  
-__Sensor assumed to be at the origin:__ no  
-__Impact on the number of points:__ reduces number of points  
+__Required descriptors:__ none
+__Output descriptor:__ none
+__Sensor assumed to be at the origin:__ no
+__Impact on the number of points:__ reduces number of points
+
+Note: when there are descriptors present, both the features (input cloud positions) and the descriptors are checked.  For example, if you have a `"normals"` descriptor, for index `i` both the position and the normal must be non-NaN to make it past this filter.  If the position was not NaN, but the normal had a NaN, both the position and the normal are filtered out.  The same is true for more generally for all descriptors.
 
 ## Shadow Point Filter <a name="shadowpointhead"></a>
 
@@ -224,11 +226,11 @@ __Impact on the number of points:__ reduces number of points
 Shadow points are noisy points usually located at point cloud edge discontinuities.
 
 __Required descriptors:__  `normals`  (see SurfaceNormalDataPointsFilter)
-__Output descriptor:__ none  
-__Sensor assumed to be at the origin:__ no  
-__Impact on the number of points:__ reduces number of points  
+__Output descriptor:__ none
+__Sensor assumed to be at the origin:__ no
+__Impact on the number of points:__ reduces number of points
 
-*IMPORTANT:* The surface normal descriptors are required in the input point cloud. 
+*IMPORTANT:* The surface normal descriptors are required in the input point cloud.
 
 ## Voxel Grid Filter <a name="voxelgridhead"></a>
 ### Description
@@ -240,10 +242,10 @@ There are two options as to how to represent the distribution of points in a vox
 
 This filter also provides two methods for sub-sampling descriptors.  In the first, all descriptors within a voxel are averaged while in the second, only the first descriptor from a voxel is kept.
 
-__Required descriptors:__  none  
-__Output descriptor:__ outputs average or single descriptor per voxel if the input cloud contains descriptors  
-__Sensor assumed to be at the origin:__ no  
-__Impact on the number of points:__ reduces number of points  
+__Required descriptors:__  none
+__Output descriptor:__ outputs average or single descriptor per voxel if the input cloud contains descriptors
+__Sensor assumed to be at the origin:__ no
+__Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -259,7 +261,7 @@ For more information on the implementation of this filter, refer to [this tutori
 In this example, we apply the voxel grid filter using centroid down-sampling to the appartment point cloud.  The output points are shown in yellow.  You can observe a regular grid distribution of points corresponding to each voxel.  A finer degree of sub-sampling can be obtained by using smaller voxels.  This comes naturally with an increased computational cost and a larger output point cloud.
 
 |Figure:  Applying the voxel grid filter filter to the appartment point cloud. | Parameters used |
-|---|:---|  
+|---|:---|
 |![dir after](images/appt_voxel.png "Applying the voxel grid filter filter to a local point cloud") | vSizeX : 0.2 <br> vSizeY : 0.2 <br> vSizeZ : 0,2 <br> useCentroid : 1 |
 
 ## Observation Direction Filter <a name="obsdirectionhead"></a>
@@ -269,10 +271,10 @@ As opposed to the previous filters, the following does not yield a sub-sample of
 
 The returned direction vector is a vector connecting the point and the sensor, whose positions can be specified in the filter parameters.
 
-__Required descriptors:__   none  
-__Output descriptor:__ `observationDirections`  
-__Sensor assumed to be at the origin:__ yes    
-__Impact on the number of points:__ none  
+__Required descriptors:__   none
+__Output descriptor:__ `observationDirections`
+__Sensor assumed to be at the origin:__ yes
+__Impact on the number of points:__ none
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -284,7 +286,7 @@ __Impact on the number of points:__ none
 **Remark:** The following example uses a local point cloud 10 from the apartment dataset.  The filter is used to extract direction informations and a small subset of these directions is shown in the following image.  The arrows point towards the position of the sensor.  The input point cloud is color coded according to the z-elevation of the points (red represents the ceiling and blue the floor).
 
 |Figure:  Applying the observation direction filter to a local point cloud.  A small <br>subset of point observation directions are displayed   | Parameters used |
-|---|:---|  
+|---|:---|
 |![dir after](images/appt_obs_dir.png "Applying the observation direction filter to a local point cloud") | x : 0 <br> y : 0 <br> z : 0 |
 
 ## Surface Normal Filter <a name="surfacenormalhead"></a>
@@ -294,14 +296,14 @@ The surface normal to each point is estimated by finding a number of neighboring
 
 Remark that that given a surface, the normal vector can point in two possible directions.  Following the apartment example used herein throughout, the normal vector of a wall can point inside towards the room, or outside the apartment.  To align all normal vectors in the same direction, the [orient normals filter](#orientnormalshead) can be used.
 
-__Required descriptors:__ none   
-__Output descriptor:__   
-`normals`  
-`densities`  
-`eigValues`  
-`eigVectors`  
-__Sensor assumed to be at the origin:__ no  
-__Impact on the number of points:__ none  
+__Required descriptors:__ none
+__Output descriptor:__
+`normals`
+`densities`
+`eigValues`
+`eigVectors`
+__Sensor assumed to be at the origin:__ no
+__Impact on the number of points:__ none
 
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
@@ -319,7 +321,7 @@ __Impact on the number of points:__ none
 In this example, we again use a local point cloud of the apartment. You may recognize the input point cloud as a small portion of the local cloud used in the observation direction filter.  The surface normals are extracted using 20 neighboring points and epsilon=0.  In this example, for clarity, we only view a wall section of one of the apartment dataset.  A random set of normal vectors is shown in the figure with arrows.  When looking at the arrow directions on the wall, one may see normal vectors either pointing downwards into the apartment or outside the apartment.
 
 |Figure:  Applying the observation direction filter to a local point cloud.  A small <br>subset of point observation directions are displayed   | Parameters used |
-|---|:---|  
+|---|:---|
 |![norm after](images/appt_norm.png "Extracting surface normals of a portion of the apartment point cloud") | knn : 20 <br> epsilon : 0 <br> keepNormals : 1 <br> keepDensities : 1|
 
 ## Orient Normals Filter <a name="orientnormalshead"></a>
@@ -327,12 +329,12 @@ In this example, we again use a local point cloud of the apartment. You may reco
 ### Description
 As explained previously, neighboring surface normal vectors obtained from the surface normals filter, do not have the same orientation.  This filter enforces this constraint and reorients vectors from the same surface in a consistent direction.  Vectors are reoriented to either point towards the center (inwards), or away from the center (outwards).
 
-__Required descriptors:__  
-  `observationDirections` (see ObservationDirectionDataPointsFilter)   
-  `normals` (see SurfaceNormalDataPointsFilter, SamplingSurfaceNormalDataPointsFilter)      
-__Output descriptor:__ none  
-__Sensor assumed to be at the origin:__ yes  
-__Impact on the number of points:__ none 
+__Required descriptors:__
+  `observationDirections` (see ObservationDirectionDataPointsFilter)
+  `normals` (see SurfaceNormalDataPointsFilter, SamplingSurfaceNormalDataPointsFilter)
+__Output descriptor:__ none
+__Sensor assumed to be at the origin:__ yes
+__Impact on the number of points:__ none
 
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -354,13 +356,13 @@ The same input section is used as for extracting the surface normals in the prev
 ### Description
 The above filters extract surface normals at every point in the point cloud.  In point clouds representing planar surfaces however, a significant redundant information is contained in adjacent normal vectors.  This filter attempts to both reduce the number of points within a point cloud and the number of different normal vectors.  The first is achieved by performing either random sub-sampling as seen previously, or by using one point per box (bin sub-sampling).  The latter is achieved by recursively decomposing the point-cloud space into boxes until each box contains at most knn points.  A single normal vector is computed from the knn points in each box.
 
-__Required descriptors:__  none  
-__Output descriptor:__ 
-`normals`   
-`densities`  
-`eigValues`   
-`eigVectors`  
-__Sensor assumed to be at the origin:__ yes   
+__Required descriptors:__  none
+__Output descriptor:__
+`normals`
+`densities`
+`eigValues`
+`eigVectors`
+__Sensor assumed to be at the origin:__ yes
 __Impact on the number of points:__ reduces number of points
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -394,9 +396,9 @@ We reuse the same apartment section to illustrate the sampling of normal vectors
 ### Description
 This filter is used to augment points with an estimation of position uncertainty based on sensor specifications.  So far the [SICK LMS](http://www.sick.com/group/EN/home/products/product_news/laser_measurement_systems/Pages/lms100.aspx), [Hokuyo](http://www.hokuyo-aut.jp/02sensor/index.html#scanner) URG-04LX and UTM-30LX, as well as the Microsoft [Kinect](http://www.microsoft.com/en-us/kinectforwindows/) and Asus [Xtion](http://www.asus.com/Multimedia/Xtion_PRO_LIVE/) sensors are supported.  The uncertainty or noise radius is represented in meters, and can be adjusted by varying a gain parameter which amplifies predefined uncertainty levels.
 
-__Required descriptors:__  none  
-__Output descriptor:__ `simpleSensorNoise`  
-__Sensor assumed to be at the origin:__ yes  
+__Required descriptors:__  none
+__Output descriptor:__ `simpleSensorNoise`
+__Sensor assumed to be at the origin:__ yes
 __Impact on the number of points:__ none
 
 |Parameter  |Description  |Default value    |Allowable range|
@@ -417,5 +419,5 @@ In the following image we show a side view of local point cloud 3 in the dataset
 The number of points in a point cloud can be reduced by taking random point subsamples.  The filter is parametrized so that a fixed number of points - selected uniformly at random - are 'rejected' in the filtering process.
 
 ## Where To Go From Here
-This concludes the overview of data point filters.  For a tutorial on writing a simple application for applying data point filters to an input point cloud, go [here](ApplyingDatafilters.md).  To learn more about the general configuration of the ICP chain go [here](DefaultICPConfig.md).  
+This concludes the overview of data point filters.  For a tutorial on writing a simple application for applying data point filters to an input point cloud, go [here](ApplyingDatafilters.md).  To learn more about the general configuration of the ICP chain go [here](DefaultICPConfig.md).
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -32,9 +32,10 @@ Advanced<a name="advanced"></a>
 - [Example: Configure an ICP solution without yaml](icpWithoutYaml.md)
 - Measuring Hausdorff distance, Haussdorff quantile and mean residual error? [See this discussion for code examples.](https://github.com/ethz-asl/libpointmatcher/issues/125)
 - How to compute the residual error with `ErrorMinimizer::getResidualError(...)` [See the example code provided here.](https://github.com/ethz-asl/libpointmatcher/issues/193#issue-203885636)
-- How to I build a global map from a sequence of scans? [See the example align_sequence.cpp](../examples/align_sequence.cpp ).
+- How do I build a global map from a sequence of scans? [See the example align_sequence.cpp](../examples/align_sequence.cpp ).
 - How to minimize the error with translation, rotation and scale? [See this example.](https://github.com/ethz-asl/libpointmatcher/issues/188#issuecomment-270960696)
 - How to do a nearest neighbor search between two point clouds without an ICP object? [See the comments here.](https://github.com/ethz-asl/libpointmatcher/issues/193#issuecomment-276093785)
+- How do I build I specify data descriptors (e.g., `"normals"`) manually? [See the example manual_data_and_descriptors.cpp](../examples/manual_data_and_descriptors.cpp ).
 
 Developer<a name="developer"></a>
 ---------
@@ -42,7 +43,7 @@ Developer<a name="developer"></a>
 - [Creating a Transformation](TransformationDev.md)
 - [Creating unit tests](UnitTestDev.md)
 
-**Note**: if you don't find what you need, don't hesitate to propose or participate to new tutorials. 
+**Note**: if you don't find what you need, don't hesitate to propose or participate to new tutorials.
 
 ---
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,3 +22,6 @@ target_link_libraries(icp_advance_api pointmatcher)
 
 add_executable(icp_customized icp_customized.cpp)
 target_link_libraries(icp_customized pointmatcher)
+
+add_executable(manual_data_and_descriptors manual_data_and_descriptors.cpp)
+target_link_libraries(manual_data_and_descriptors pointmatcher)

--- a/examples/manual_data_and_descriptors.cpp
+++ b/examples/manual_data_and_descriptors.cpp
@@ -1,0 +1,385 @@
+// kate: replace-tabs off; indent-width 4; indent-mode normal
+// vim: ts=4:sw=4:noexpandtab
+/*
+
+Copyright (c) 2010--2012,
+François Pomerleau and Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the authors at <f dot pomerleau at gmail dot com> and
+<stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "pointmatcher/PointMatcher.h"
+
+#include <Eigen/Dense>    // various vector operations
+#include <Eigen/Geometry> // Eigen::Affine3f (convenience transformations)
+#include <cmath>          // std::cos, std::sin
+#include <xmmintrin.h>    // _mm_malloc
+#include <iostream>       // printing messages
+#include <limits>         // std::numeric_limits<float>::quiet_NaN()
+
+/// A simple struct for housing four floats, could be replaced with Eigen::Vector4f.
+struct alignas(16u) float4 {
+	float x, y, z, w;
+};
+
+/// Convenience method for making a float4 from four floats.
+inline float4 make_float4(float x, float y, float z, float w) {
+	return {x, y, z, w};
+}
+
+/// Convenience method for making a float4 from a single float.
+inline float4 make_float4(float v) {
+	return {v, v, v, v};
+}
+
+
+/// Simulated range image width.
+static constexpr unsigned Width = 640u;
+
+/// Simulated range image height.
+static constexpr unsigned Height = 480u;
+
+/**
+ * \brief Generates a Width * Height 'sin-cos' point cloud.
+ *
+ * It is worth acknowledging that this method does not simulate an actual range
+ * image, the X and Y positions will range from 0.0 to 2 pi.  This is done for
+ * simplicity / clarity of generating the data, but the real goal of this
+ * tutorial is to demonstrate how you can supply externally managed data to
+ * libpointmatcher.
+ *
+ * That is, the important aspect is generating Width * Height data points, not
+ * what the actual 3D positions generated are.
+ *
+ * \param positions
+ *     The already-allocated array of positions to generate data for.
+ */
+void generatePointCloud(float4 *positions) {
+	static constexpr float TwoPi = 6.283185307179586476925286766559005768394338798750211641949f;
+	// simple 'linspace' range from 0 to 2pi spread across each dimension
+	static constexpr float start = 0.0;
+	static constexpr float stop  = TwoPi;
+	static constexpr float dx = (stop - start) / static_cast<float>(Width  - 1);
+	static constexpr float dy = (stop - start) / static_cast<float>(Height - 1);
+
+	// populate all of the positions
+	for (unsigned idx = 0; idx < Width * Height; ++idx) {
+		unsigned col = idx % Width;
+		unsigned row = idx / Width;
+
+		float x = static_cast<float>(col) * dx;
+		float y = static_cast<float>(row) * dy;
+
+		/* the last coordinate 'w' is the homogeneous coordinate.  in this
+		 * scenario we should make sure to set it to 1.0f so that if / when
+		 * homogenization occurs, the positions will not change.
+		 *
+		 * adding 10.0f to 'z' to make the "view point" of (0, 0, 0) valid, as
+		 * well as typically range data will not have negative measurements. */
+		positions[idx] = make_float4(
+			x, y, std::cos(x) * std::sin(y) + 10.0f, 1.0f
+		);
+	}
+}
+
+/**
+ * \brief Computes the surface normals for the specified positions.
+ *
+ * This method performs a very naive approximation of the surface normals, doing
+ * a cross product between the north, south, east, and west neighbors.  This
+ * will NEVER produce normals as nice as the NormalFilter supplied by
+ * libpointmatcher.  However, this method is easy to understand, and (due to its
+ * naivety) much faster to compute.
+ *
+ * As with the \ref generatePointCloud method, this method is not to be taken as
+ * an authoritative way of computing normals.  It is one of many options in this
+ * domain, and exists only to demonstrate how you can coordinate externally
+ * computed normals with libpointmatcher.
+ *
+ * \remark
+ *     Though you could be more clever with the borders in this method, the
+ *     implementation here deliberately sets the borders to be NaN to show how
+ *     the NaN Filter for libpointmatcher behaves -- all positions are valid (no
+ *     NaN), but the normals need to get filtered.  Libpointmatcher will handle
+ *     this (and all other descriptors) correctly for you.
+ *
+ * \param positions
+ *     The already computed positions of the input point cloud.
+ *
+ * \param normals
+ *     Where to store the computed normals for each point.
+ */
+void computeNormals(const float4 *positions, float4 *normals) {
+	for (unsigned idx = 0; idx < Width * Height; ++idx) {
+		unsigned x = idx % Width;
+		unsigned y = idx / Width;
+
+		// set the boundaries to NaN
+		if (x == 0 || x == Width - 1 || y == 0 || y == Height - 1) {
+			normals[idx] = make_float4(std::numeric_limits<float>::quiet_NaN());
+			continue;
+		}
+
+		// at this point, we can be sure that north / south / east / west are
+		// valid indices
+		unsigned north_idx = (y - 1) * Width + (x + 0);
+		unsigned south_idx = (y + 1) * Width + (x + 0);
+		unsigned west_idx  = (y + 0) * Width + (x - 1);
+		unsigned east_idx  = (y + 0) * Width + (x + 1);
+
+		// read in the positions
+		const float4 &north_4 = positions[north_idx];
+		const float4 &south_4 = positions[south_idx];
+		const float4 &west_4  = positions[west_idx];
+		const float4 &east_4  = positions[east_idx];
+
+		// using Eigen::Vector3f for convenience of vector operations
+		Eigen::Vector3f west(west_4.x, west_4.y, west_4.z);
+		Eigen::Vector3f north(north_4.x, north_4.y, north_4.z);
+		Eigen::Vector3f south(south_4.x, south_4.y, south_4.z);
+		Eigen::Vector3f east(east_4.x, east_4.y, east_4.z);
+
+		/* compute the normal, the cross product is setup this way because we
+		 * have a "view point" at (0, 0, 0):
+		 *
+		 *                 N
+		 *                 ^
+		 *                 |
+		 *             W --+--> E
+		 *                 |
+		 *                 S
+		 */
+		Eigen::Vector3f v1 = east  - west;
+		Eigen::Vector3f v2 = north - south;
+		Eigen::Vector3f normal = v1.cross(v2).normalized();
+
+		/* assign the computed normal, we ignore the 'w' component later on so
+		 * setting it to 0.0f here does not have any real meaning.  some normal
+		 * estimation methods you may find (e.g. in the point cloud library)
+		 * may treat 'w' as 'curvature' which can have meaning. */
+		normals[idx] = make_float4(normal.x(), normal.y(), normal.z(), 0.0f);
+	}
+}
+
+/**
+ * \brief Performs an arbitrary transformation of the reference positions and
+ *        stores this in the reading positions.
+ *
+ * \param referencePositions
+ *     The input positions to transform.
+ *
+ * \param readingPositions
+ *     Where to store the transformed positions.
+ *
+ * \param xform
+ *     The transformation to be applied.  Assumed to consist of only a rotation
+ *     and / or translation (that is, no scaling).  This assumption is not
+ *     checked, but violating it invalidates the way this method treats the
+ *     homogeneous coordinate of the positions.
+ */
+void transformReference(const float4 *referencePositions, float4 *readingPositions,
+                        const Eigen::Affine3f &xform) {
+	for (unsigned idx = 0; idx < Width * Height; ++idx) {
+		const float4 &ref_4 = referencePositions[idx];
+		Eigen::Vector3f ref(ref_4.x, ref_4.y, ref_4.z);
+		Eigen::Vector3f read = xform * ref;
+		readingPositions[idx] = make_float4(read.x(), read.y(), read.z(), 1.0f);
+	}
+}
+
+/**
+  *
+  */
+int main(void)
+{
+	/* allocate memory for the positions and normals, in this tutorial we are
+	 * managing everything manually, but it is important to understand that when
+	 * we use Eigen::Map later, if you do not allocate aligned memory, then you
+	 * need to make sure you map using the Eigen::DontAlign flag. */
+	// data for the reference frame
+	float4 *reference_positions = (float4 *)_mm_malloc(
+		Width * Height * sizeof(float4), 16u
+	);
+	float4 *reference_normals = (float4 *)_mm_malloc(
+		Width * Height * sizeof(float4), 16u
+	);
+	// data for the reading frame
+	float4 *reading_positions = (float4 *)_mm_malloc(
+		Width * Height * sizeof(float4), 16u
+	);
+	float4 *reading_normals = (float4 *)_mm_malloc(
+		Width * Height * sizeof(float4), 16u
+	);
+
+	/* initialize the problem:
+	 * 1. Generate the reference positions.
+	 * 2. Compute the reference normals.
+	 * 3. Apply an arbitrary transformation to get a reading frame.
+	 * 4. Compute the reading frame normals. */
+	generatePointCloud(reference_positions);
+	computeNormals(reference_positions, reference_normals);
+	// there is nothing meaningful about this specific transformation, it is
+	// just to get a different frame to run ICP with
+	Eigen::Affine3f xform = Eigen::Affine3f::Identity();
+	xform.translation() = Eigen::Vector3f::Constant(10.0f);
+	xform.linear() = Eigen::AngleAxisf(
+		0.5f * M_PI, Eigen::Vector3f::UnitZ()
+	).toRotationMatrix();
+	transformReference(reference_positions, reading_positions, xform);
+	computeNormals(reading_positions, reading_normals);
+
+	/* At last we finally have the data available for a reference and reading
+	 * frame.  In the context of your own application, this would be where you
+	 * actually start working -- you already have the positions and computed the
+	 * normals, now you just need a way of interfacing with libpointmatcher.
+	 *
+	 * We utilize the Eigen::Map for these purposes, but it is important to
+	 * understand that you need to have a firm understanding of how your data
+	 * is laid out, and what the expectations of libpointmatcher are.
+	 *
+	 *     http://libpointmatcher.readthedocs.io/en/latest/Pointclouds/#features-matrix
+	 *
+	 * Libpoint matcher expects data laid out in rows:
+	 *
+	 *     +-                       -+
+	 *     | x_0  ...  x_i  ...  x_n |
+	 *     | y_0  ...  y_i  ...  y_n |
+	 *     | z_0  ...  z_i  ...  z_n |
+	 *     | w_0  ...  w_i  ...  w_n |
+	 *     +-                       -+
+	 *
+	 * Above, we allocated data as an "array of structs", laid out as
+	 *
+	 *     +-                  -+
+	 *     | x_0  y_0  z_0  w_0 |
+	 *     |  .    .    .    .  |
+	 *     | x_i  y_i  z_i  w_i |
+	 *     |  .    .    .    .  |
+	 *     | x_n  y_n  z_n  w_n |
+	 *     +-                  -+
+	 *
+	 * So our data should be thought of as row major storage.  As it turns out,
+	 * though, this is perfectly acceptable *ONLY* because when we do a map with
+	 * Eigen, Eigen by default assumes column major storage.  So when we map
+	 * using 4 rows and N columns, this all works out in the end.
+	 *
+	 * Similarly, with the normals, we employ the same mapping scheme.  In this
+	 * example code, we are also using `float4` for the normals for
+	 * demonstrative purposes.  In your own application, you may or may not need
+	 * the extra `w` component.  If not, you can simply use a `float3` or
+	 * `Eigen::Vector3f` etc.  In the example below, since we have this `w`
+	 * component, we need to take one extra step and effectively just ignore `w`
+	 * as far as libpointmatcher is concerned.  This is why we use `topRows(3)`:
+	 * libpointmatcher expects "normals" to be laid out as <nx, ny, nz>.  Since
+	 * our mapped type will have row 0 as x, row 1 as y, row 2 as z, and row 3
+	 * as w, we simply want the top three rows.
+	 */
+	using PM = PointMatcher<float>;
+	using DP = typename PM::DataPoints;
+	using Matrix = typename PM::Matrix;
+
+	/***************************************************************************
+	 * create the reference frame                                              *
+	 **************************************************************************/
+	DP reference;
+	// assign the positions
+	reference.features = Eigen::Map<Matrix>(
+		reinterpret_cast<float *>(reference_positions), 4, Width * Height
+	);
+	reference.featureLabels.push_back({"X", 1});
+	reference.featureLabels.push_back({"Y", 1});
+	reference.featureLabels.push_back({"Z", 1});
+	reference.featureLabels.push_back({"W", 1});
+
+	// assign the normals descriptor
+	reference.allocateDescriptor("normals", 3);
+	Matrix reference_normals_mat = Eigen::Map<Matrix>(
+		reinterpret_cast<float *>(reference_normals), 4, Width * Height
+	);
+	reference.addDescriptor("normals", reference_normals_mat.topRows(3));
+
+	/***************************************************************************
+	 * create the reading frame                                                *
+	 **************************************************************************/
+	DP reading;
+	// assign the positions
+	reading.features = Eigen::Map<Matrix>(
+		reinterpret_cast<float *>(reading_positions), 4, Width * Height
+	);
+	reading.featureLabels.push_back({"X", 1});
+	reading.featureLabels.push_back({"Y", 1});
+	reading.featureLabels.push_back({"Z", 1});
+	reading.featureLabels.push_back({"W", 1});
+
+	// assign the normals descriptor
+	reading.allocateDescriptor("normals", 3);
+	Matrix reading_normals_mat = Eigen::Map<Matrix>(
+		reinterpret_cast<float *>(reading_normals), 4, Width * Height
+	);
+	reference.addDescriptor("normals", reading_normals_mat.topRows(3));
+
+	/***************************************************************************
+	 * perform the registration                                                *
+	 **************************************************************************/
+	PM::ICP icp;
+	icp.setDefault();// see icp_customized for custom matcher / error minimizer
+
+	// add a NaN data filter
+	PointMatcherSupport::Parametrizable::Parameters params; // reused below
+	PM::DataPointsFilter *nanFilter = PM::get().DataPointsFilterRegistrar.create(
+		"RemoveNaNDataPointsFilter", params
+	);
+	params.clear();
+	icp.readingDataPointsFilters.push_back(nanFilter);
+	icp.referenceDataPointsFilters.push_back(nanFilter);
+
+	// compute the transformation to express reading in reference
+	PM::TransformationParameters T = icp(reading, reference);
+
+	// transform data to express it in reference
+	DP data_out(reading);
+	icp.transformations.apply(data_out, T);
+
+	// save files to see the results
+	reference.save("test_ref.vtk");
+	reading.save("test_data_in.vtk");
+	data_out.save("test_data_out.vtk");
+
+	std::cout << "Transform Computed: " << std::endl << T << std::endl;
+
+	std::cout << "freeing frame data" << std::endl;
+    // free the externally managed data
+    _mm_free(reference_positions);
+    _mm_free(reference_normals);
+    _mm_free(reading_positions);
+    _mm_free(reading_normals);
+    std::cout << "done freeing data" << std::endl;
+    // segfault after this ...
+
+    return 0;
+}

--- a/pointmatcher/DataPointsFiltersImpl.cpp
+++ b/pointmatcher/DataPointsFiltersImpl.cpp
@@ -90,9 +90,13 @@ void DataPointsFiltersImpl<T>::RemoveNaNDataPointsFilter::inPlaceFilter(
 	int j = 0;
 	for (int i = 0; i < nbPointsIn; ++i)
 	{
-		const BOOST_AUTO(colArray, cloud.features.col(i).array());
-		const BOOST_AUTO(hasNaN, !(colArray == colArray).all());
-		if (!hasNaN)
+		// check the features matrix for NaN
+		const BOOST_AUTO(featuresColArray, cloud.features.col(i).array());
+		const BOOST_AUTO(hasFeatureNaN, !(featuresColArray == featuresColArray).all());
+		// check the descriptors matrix for NaN
+		const BOOST_AUTO(descriptorsColArray, cloud.descriptors.col(i).array());
+		const BOOST_AUTO(hasDescriptorsNan, !(descriptorsColArray == descriptorsColArray).all());
+		if (!hasFeatureNaN && !hasDescriptorsNan)
 		{
 			cloud.setColFrom(j, cloud, i);
 			j++;
@@ -538,7 +542,7 @@ void DataPointsFiltersImpl<T>::SurfaceNormalDataPointsFilter::inPlaceFilter(
 	boost::assign::insert(param) ( "knn", toParam(knn) );
 	boost::assign::insert(param) ( "epsilon", toParam(epsilon) );
 	boost::assign::insert(param) ( "maxDist", toParam(maxDist) );
-	
+
 	KDTreeMatcher matcher(param);
 	matcher.init(cloud);
 
@@ -600,7 +604,7 @@ void DataPointsFiltersImpl<T>::SurfaceNormalDataPointsFilter::inPlaceFilter(
 			}
 		}
 
-		
+
 
 		if(keepNormals)
 		{
@@ -630,7 +634,7 @@ void DataPointsFiltersImpl<T>::SurfaceNormalDataPointsFilter::inPlaceFilter(
 				(*meanDists)(0, i) = (point - mean).norm();
 			}
 		}
-		
+
 	}
 
 	if(keepMatchedIds)
@@ -725,7 +729,7 @@ typename PointMatcher<T>::Vector DataPointsFiltersImpl<T>::SurfaceNormalDataPoin
 	Vector output(eigenVeDim*eigenVeDim);
 	for(int k=0; k < eigenVe.cols(); k++)
 	{
-		output.segment(k*eigenVeDim, eigenVeDim) = 
+		output.segment(k*eigenVeDim, eigenVeDim) =
 			eigenVe.row(k).transpose();
 	}
 
@@ -2014,8 +2018,8 @@ template<typename T>
 typename PointMatcher<T>::Vector DataPointsFiltersImpl<T>::GestaltDataPointsFilter::calculateAngles(const Matrix points, const Eigen::Matrix<T,3,1> keyPoint) const
 {
   Vector angles(points.cols());
-  
-  for (unsigned int i = 0; i<points.cols(); ++i) 
+
+  for (unsigned int i = 0; i<points.cols(); ++i)
   {
     angles(i) = atan2(points(0,i), points(1,i));
     if (angles(i) < 0)
@@ -2030,7 +2034,7 @@ typename PointMatcher<T>::Vector DataPointsFiltersImpl<T>::GestaltDataPointsFilt
 {
   Vector radii(points.cols());
 
-  for (unsigned int i = 0; i<points.cols(); ++i) 
+  for (unsigned int i = 0; i<points.cols(); ++i)
   {
     radii(i) = sqrt((points(0,i)) * (points(0,i)) + (points(1,i)) * (points(1,i)));
   }
@@ -2612,7 +2616,7 @@ void DataPointsFiltersImpl<T>::VoxelGridDataPointsFilter::inPlaceFilter(DataPoin
     unsigned int numVox = numDivX * numDivY;
     if ( featDim == 4)
         numVox *= numDivZ;
-	
+
 	if(numVox == 0)
 	{
 		throw InvalidParameter("VoxelGridDataPointsFilter: The number of voxel couldn't be computed. There might be NaNs in the feature matrix. Use the fileter RemoveNaNDataPointsFilter before this one if it's the case.");
@@ -2639,7 +2643,7 @@ void DataPointsFiltersImpl<T>::VoxelGridDataPointsFilter::inPlaceFilter(DataPoin
     }
 
     for (unsigned int p = 0; p < numPoints; p++ )
-    {	
+    {
         unsigned int i = floor(cloud.features(0,p)/vSizeX - minBoundX);
         unsigned int j = floor(cloud.features(1,p)/vSizeY- minBoundY);
         unsigned int k = 0;
@@ -2823,9 +2827,9 @@ void DataPointsFiltersImpl<T>::VoxelGridDataPointsFilter::inPlaceFilter(DataPoin
 			cloud.times.col(i) = cloud.times.col(k);
 
 	}
-	
+
 	cloud.conservativeResize(numPtsOut);
-	
+
 	//cloud.features.conservativeResize(Eigen::NoChange, numPtsOut);
 	//
 	//if (cloud.descriptors.rows() != 0)


### PR DESCRIPTION
Here's what I've got so far on manually specifying positions / normals using `Eigen::Map`.  I used a `float4` data type, but maybe this adds more confusion than it does help?  I don't find it counter-intuitive, but I hail from a CUDA background...so of course it is natural.

Opening the PR now for feedback, we can just squash the commits when its ready / if it is desired.

- `sin*cos` is kind of a bad choice, if you do [0, 2pi] it won't converge.  just did 0.5 pi to 3pi / 2.  [the translation of only z is also important](https://github.com/svenevs/libpointmatcher/blob/2926febba6eb1b0080f6f53daca88338a220d30f/examples/manual_data_and_descriptors.cpp#L248-L256).  but i think for the purposes of this demo it is sufficient
- normals are working, if you remove the `topRows(3)` and just use the map you'll get an exception from libpointmatcher
    - obviously, the normals are quite naive

Bad alignment [0, 2pi]:

![manual](https://user-images.githubusercontent.com/5871461/34966760-e8a752cc-fa12-11e7-8b24-6d8b66e176b0.jpeg)

Good enough alignment:

![manual_fixed](https://user-images.githubusercontent.com/5871461/34979456-2c273416-fa56-11e7-9a93-e4cc649c0b2f.jpeg)

- Purple: reference frame
- Teal: reading with transform applied
- Blue: reading frame


**TODO**:

- [x] features are problematic, segfault at end of program (not sure where from yet).  double free or something probably.  double free from reusing the NaN filter, created two -- one for reading and one for reference.
- [ ] need writeup on the tutorial instead of [linking from index.md](https://github.com/svenevs/libpointmatcher/blob/2926febba6eb1b0080f6f53daca88338a220d30f/doc/index.md#advanced) {revert that}
- [x] need to fix the NaN filter for descriptors (see [comment here](https://github.com/ethz-asl/libpointmatcher/issues/234#issuecomment-357778015))
    - [x] added to description, see [note at end here](https://github.com/svenevs/libpointmatcher/blob/manual_data_and_descriptors/doc/Datafilters.md#remove-nan-filter-)
        - [x] decision from you all: the datafilters markdown had whitespace trimmed from my text editor.  for the descriptions to show up they were, this required trailing whitespace.  I fixed this with newlines, but it was ugly.  So I made them all bullet lists.  See [the bullet version](https://github.com/svenevs/libpointmatcher/blob/manual_data_and_descriptors/doc/Datafilters.md#surface-normal-filter-) vs [the original version](https://github.com/ethz-asl/libpointmatcher/blob/master/doc/Datafilters.md#surface-normal-filter-).  I can find a way to un-do this easily enough.  But I'm not sure that relying on trailing whitespace is valid markdown, and it may break in the future.  I couldn't figure out how to build the RTD docs, so don't know what that looks like.  Just let me know what you want.
    - [x] added explicit nan test, test 1 validates existing behavior, test 2 validates NaN only in normals makes both get skipped
    - [ ] [**Confusion: why don't I need to check that `.col(i)` is a valid index for the descriptors**?](https://github.com/svenevs/libpointmatcher/blob/a93273ff385d946cacfc24c81b13719040432472/pointmatcher/DataPointsFiltersImpl.cpp#L96-L98)