### PR TITLE
Fix the MaxPointCount data filter (see issue #245)

### DIFF
--- a/pointmatcher/DataPointsFilters/MaxPointCount.cpp
+++ b/pointmatcher/DataPointsFilters/MaxPointCount.cpp
@@ -66,36 +66,37 @@ MaxPointCountDataPointsFilter<T>::filter(const DataPoints& input)
 template<typename T>
 void MaxPointCountDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 {
-	const size_t N = static_cast<size_t> (cloud.features.cols() - 1) ;
+	const size_t N = static_cast<size_t> (cloud.features.cols() - 1);
 	
-	if (maxCount < N) 
+	if (maxCount <= N) 
 	{
+		//Re-init seed at each call, to ensure same results
 		std::srand(seed);
 		
-		for(size_t j=0; j<=maxCount; ++j)
+		for(size_t j=0; j<maxCount; ++j)
 		{
 			//Get a random index in [j; N]
 			const size_t idx = j + static_cast<size_t>((N-j)*(static_cast<float>(std::rand()/static_cast<float>(RAND_MAX))));
 			
 			//Switch columns j and idx
-			auto feat = cloud.features.col(j);
+			const auto feat = cloud.features.col(j);
 			cloud.features.col(j) = cloud.features.col(idx);
 			cloud.features.col(idx) = feat;
 			
 			if (cloud.descriptors.cols() > 0)
 			{
-				auto desc = cloud.descriptors.col(j);
+				const auto desc = cloud.descriptors.col(j);
 				cloud.descriptors.col(j) = cloud.descriptors.col(idx);
 				cloud.descriptors.col(idx) = desc;
 			}
 			if (cloud.times.cols() > 0)
 			{
-				auto time = cloud.times.col(j);
+				const auto time = cloud.times.col(j);
 				cloud.times.col(j) = cloud.times.col(idx);
 				cloud.times.col(idx) = time;
 			}	
 		}
-		
+		//Resize the cloud
 		cloud.conservativeResize(maxCount);
 	}
 }

--- a/pointmatcher/DataPointsFilters/MaxPointCount.h
+++ b/pointmatcher/DataPointsFilters/MaxPointCount.h
@@ -61,8 +61,8 @@ struct MaxPointCountDataPointsFilter: public PointMatcher<T>::DataPointsFilter
 		;
 	}
 
-	const unsigned maxCount;
-	unsigned seed;
+	const size_t maxCount;
+	size_t seed;
 
 	MaxPointCountDataPointsFilter(const Parameters& params = Parameters());
 	virtual ~MaxPointCountDataPointsFilter() {};

--- a/pointmatcher/DataPointsFilters/MaxPointCount.h
+++ b/pointmatcher/DataPointsFilters/MaxPointCount.h
@@ -56,8 +56,8 @@ struct MaxPointCountDataPointsFilter: public PointMatcher<T>::DataPointsFilter
 	inline static const ParametersDoc availableParameters()
 	{
 		return boost::assign::list_of<ParameterDoc>
-		( "seed", "srand seed", "1", "0", "2147483647", &P::Comp<unsigned> )
-		( "maxCount", "maximum number of points", "1000", "0", "2147483647", &P::Comp<unsigned> )
+		( "seed", "srand seed", "1", "0", "2147483647", &P::Comp<size_t> )
+		( "maxCount", "maximum number of points", "1000", "0", "2147483647", &P::Comp<size_t> )
 		;
 	}
 


### PR DESCRIPTION
I rewrite the algorithm for this filter to ensure `O(maxCount)` complexity and in a more comprehensive way as follow:
```python
for j in [0, maxCount[
  pick random index idx in [j; N[
  switch columns j and idx
end
resize pointcloud
```
I chose to switch the columns instead of just overwrite the current column by the one randomly chosen to offer the possibility to randomly select this column after.

Plus, I add a new unit test to validate the MaxPointCount data filter.