### PR TITLE
Add a Quadree struct to manage 2D point

### DIFF
--- a/pointmatcher/DataPointsFilters/OctreeGrid.cpp
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.cpp
@@ -57,7 +57,7 @@ OctreeGridDataPointsFilter<T>::FirstPtsSampler::FirstPtsSampler(DataPoints& dp):
 }
 
 template <typename T>
-template<template<typename> typename Tree>
+template<template<typename> class Tree>
 bool OctreeGridDataPointsFilter<T>::FirstPtsSampler::operator()(Tree<T>& oc)
 {
 	if(oc.isLeaf() and not oc.isEmpty())
@@ -107,7 +107,7 @@ OctreeGridDataPointsFilter<T>::RandomPtsSampler::RandomPtsSampler(DataPoints& dp
 	std::srand(seed);
 }
 template<typename T>
-template<template<typename> typename Tree>
+template<template<typename> class Tree>
 bool OctreeGridDataPointsFilter<T>::RandomPtsSampler::operator()(Tree<T>& oc)
 {
 	if(oc.isLeaf() and not oc.isEmpty())
@@ -155,7 +155,7 @@ OctreeGridDataPointsFilter<T>::CentroidSampler::CentroidSampler(DataPoints& dp):
 }
 	
 template<typename T>
-template<template<typename> typename Tree>
+template<template<typename> class Tree>
 bool OctreeGridDataPointsFilter<T>::CentroidSampler::operator()(Tree<T>& oc)
 {
 	if(oc.isLeaf() and not oc.isEmpty())
@@ -265,7 +265,7 @@ void OctreeGridDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 }
 
 template <typename T>
-template<template<typename> typename Tree>
+template<template<typename> class Tree>
 void OctreeGridDataPointsFilter<T>::applySampler(DataPoints& cloud)
 {
 	Tree<T> oc;

--- a/pointmatcher/DataPointsFilters/OctreeGrid.cpp
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.cpp
@@ -51,15 +51,14 @@ void swapCols(typename PointMatcher<T>::DataPoints& self,
 
 //Define Visitor classes to apply processing
 template<typename T>
-template<template<typename> typename Tree>
-OctreeGridDataPointsFilter<T>::FirstPtsSampler<Tree>::FirstPtsSampler(DataPoints& dp) 
-	: idx{0}, pts(dp) 
+OctreeGridDataPointsFilter<T>::FirstPtsSampler::FirstPtsSampler(DataPoints& dp):
+	idx{0}, pts(dp) 
 {
 }
 
 template <typename T>
 template<template<typename> typename Tree>
-bool OctreeGridDataPointsFilter<T>::FirstPtsSampler<Tree>::operator()(Tree<T>& oc)
+bool OctreeGridDataPointsFilter<T>::FirstPtsSampler::operator()(Tree<T>& oc)
 {
 	if(oc.isLeaf() and not oc.isEmpty())
 	{			
@@ -85,8 +84,7 @@ bool OctreeGridDataPointsFilter<T>::FirstPtsSampler<Tree>::operator()(Tree<T>& o
 }
  
 template <typename T>
-template<template<typename> typename Tree>
-bool OctreeGridDataPointsFilter<T>::FirstPtsSampler<Tree>::finalize()
+bool OctreeGridDataPointsFilter<T>::FirstPtsSampler::finalize()
 {
 	//Resize point cloud
 	pts.conservativeResize(idx);
@@ -97,23 +95,20 @@ bool OctreeGridDataPointsFilter<T>::FirstPtsSampler<Tree>::finalize()
 
 
 template<typename T>
-template<template<typename> typename Tree>
-OctreeGridDataPointsFilter<T>::RandomPtsSampler<Tree>::RandomPtsSampler(DataPoints& dp) 
-	: OctreeGridDataPointsFilter<T>::template FirstPtsSampler<Tree>{dp}, seed{1}
+OctreeGridDataPointsFilter<T>::RandomPtsSampler::RandomPtsSampler(DataPoints& dp) 
+	: OctreeGridDataPointsFilter<T>::FirstPtsSampler{dp}, seed{1}
+{
+	std::srand(seed);
+}
+template<typename T>
+OctreeGridDataPointsFilter<T>::RandomPtsSampler::RandomPtsSampler(DataPoints& dp, const std::size_t seed_): 
+	OctreeGridDataPointsFilter<T>::FirstPtsSampler{dp}, seed{seed_}
 {
 	std::srand(seed);
 }
 template<typename T>
 template<template<typename> typename Tree>
-OctreeGridDataPointsFilter<T>::RandomPtsSampler<Tree>::RandomPtsSampler(
-	DataPoints& dp, const std::size_t seed_
-): OctreeGridDataPointsFilter<T>::template FirstPtsSampler<Tree>{dp}, seed{seed_}
-{
-	std::srand(seed);
-}
-template<typename T>
-template<template<typename> typename Tree>
-bool OctreeGridDataPointsFilter<T>::RandomPtsSampler<Tree>::operator()(Tree<T>& oc)
+bool OctreeGridDataPointsFilter<T>::RandomPtsSampler::operator()(Tree<T>& oc)
 {
 	if(oc.isLeaf() and not oc.isEmpty())
 	{			
@@ -144,10 +139,9 @@ bool OctreeGridDataPointsFilter<T>::RandomPtsSampler<Tree>::operator()(Tree<T>& 
 }
 	
 template<typename T>
-template<template<typename> typename Tree>
-bool OctreeGridDataPointsFilter<T>::RandomPtsSampler<Tree>::finalize()
+bool OctreeGridDataPointsFilter<T>::RandomPtsSampler::finalize()
 {
-	bool ret = FirstPtsSampler<Tree>::finalize();
+	bool ret = FirstPtsSampler::finalize();
 	//Reset seed
 	std::srand(seed);
 	
@@ -155,15 +149,14 @@ bool OctreeGridDataPointsFilter<T>::RandomPtsSampler<Tree>::finalize()
 }
 
 template<typename T>
-template<template<typename> typename Tree>
-OctreeGridDataPointsFilter<T>::CentroidSampler<Tree>::CentroidSampler(DataPoints& dp)  
-	: OctreeGridDataPointsFilter<T>::template FirstPtsSampler<Tree>{dp}
+OctreeGridDataPointsFilter<T>::CentroidSampler::CentroidSampler(DataPoints& dp):
+	OctreeGridDataPointsFilter<T>::FirstPtsSampler{dp}
 {
 }
 	
 template<typename T>
 template<template<typename> typename Tree>
-bool OctreeGridDataPointsFilter<T>::CentroidSampler<Tree>::operator()(Tree<T>& oc)
+bool OctreeGridDataPointsFilter<T>::CentroidSampler::operator()(Tree<T>& oc)
 {
 	if(oc.isLeaf() and not oc.isEmpty())
 	{			
@@ -230,7 +223,7 @@ bool OctreeGridDataPointsFilter<T>::CentroidSampler<Tree>::operator()(Tree<T>& o
 
 // OctreeGridDataPointsFilter
 template <typename T>
-OctreeGridDataPointsFilter<T>::OctreeGridDataPointsFilter(const Parameters& params) :
+OctreeGridDataPointsFilter<T>::OctreeGridDataPointsFilter(const Parameters& params):
 	PointMatcher<T>::DataPointsFilter("OctreeGridDataPointsFilter", 
 		OctreeGridDataPointsFilter::availableParameters(), params),
 	parallel_build{Parametrizable::get<bool>("buildParallel")},
@@ -294,21 +287,21 @@ void OctreeGridDataPointsFilter<T>::applySampler(DataPoints& cloud){
 	{
 		case SamplingMethod::FIRST_PTS:
 		{
-			FirstPtsSampler<Tree> sampler(cloud);
+			FirstPtsSampler sampler(cloud);
 			oc.visit(sampler);
 			sampler.finalize();
 			break;
 		}
 		case SamplingMethod::RAND_PTS:
 		{
-			RandomPtsSampler<Tree> sampler(cloud); //FIXME: add seed parameter
+			RandomPtsSampler sampler(cloud); //FIXME: add seed parameter
 			oc.visit(sampler);
 			sampler.finalize();
 			break;
 		}
 		case SamplingMethod::CENTROID:
 		{
-			CentroidSampler<Tree> sampler(cloud);
+			CentroidSampler sampler(cloud);
 			oc.visit(sampler);
 			sampler.finalize();
 			break;

--- a/pointmatcher/DataPointsFilters/OctreeGrid.cpp
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.cpp
@@ -266,8 +266,9 @@ void OctreeGridDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 
 template <typename T>
 template<template<typename> typename Tree>
-void OctreeGridDataPointsFilter<T>::applySampler(DataPoints& cloud){
-	Tree<T> oc{};
+void OctreeGridDataPointsFilter<T>::applySampler(DataPoints& cloud)
+{
+	Tree<T> oc;
 	
 	switch(buildMethod) 
 	{

--- a/pointmatcher/DataPointsFilters/OctreeGrid.h
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.h
@@ -72,13 +72,13 @@ struct OctreeGridDataPointsFilter : public PointMatcher<T>::DataPointsFilter
 
 	inline static const std::string description()
 	{
-		return "Construct an Octree grid representation of the point cloud. Constructed either by limiting the number of point in each octant or by limiting the size of the bounding box. Down-sample by taking either the first or a random point, or compute the centroid.";
+		return "Construct an Octree/Quadtree grid representation of the point cloud. Constructed either by limiting the number of point in each octant or by limiting the size of the bounding box. Down-sample by taking either the first or a random point, or compute the centroid.";
 	}
 
 	inline static const ParametersDoc availableParameters()
 	{
 		return boost::assign::list_of<ParameterDoc>
-		( "buildMethod", "Method to build the Octree: maxPoint (0), maxSize (1)", "0", "0", "1", &P::Comp<int> )
+		( "buildMethod", "Method to build the Octree/Quadtree: maxPoint (0), maxSize (1)", "0", "0", "1", &P::Comp<int> )
 		( "buildParallel", "If 1 (true), use threads to build the octree.", "1", "0", "1", P::Comp<bool> )
 		( "maxPointByNode", "Number of point under which the octree stop dividing.", "1", "1", "4294967295", &P::Comp<std::size_t> )
 		( "maxSizeByNode", "Size of the bounding box under which the octree stop dividing.", "0.01", "0.0001", "+inf", &P::Comp<T> )

--- a/pointmatcher/DataPointsFilters/OctreeGrid.h
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.h
@@ -101,7 +101,7 @@ public:
 		FirstPtsSampler(DataPoints& dp);
 		virtual ~FirstPtsSampler(){}
 		
-		template<template<typename> typename Tree>
+		template<template<typename> class Tree>
 		bool operator()(Tree<T>& oc);
 		
 		virtual bool finalize();
@@ -120,7 +120,7 @@ public:
 		RandomPtsSampler(DataPoints& dp, const std::size_t seed_);
 		virtual ~RandomPtsSampler(){}
 	
-		template<template<typename> typename Tree>
+		template<template<typename> class Tree>
 		bool operator()(Tree<T>& oc);
 		
 		virtual bool finalize();
@@ -136,7 +136,7 @@ public:
 	
 		virtual ~CentroidSampler(){}
 	
-		template<template<typename> typename Tree>
+		template<template<typename> class Tree>
 		bool operator()(Tree<T>& oc);
 	};
 
@@ -165,7 +165,7 @@ public:
 	virtual void inPlaceFilter(DataPoints& cloud);
 	
 protected:
-	template<template<typename> typename Tree>
+	template<template<typename> class Tree>
 	void applySampler(DataPoints& cloud);
 };
 

--- a/pointmatcher/DataPointsFilters/OctreeGrid.h
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.h
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /*!
  * \class OctreeGridDataPointsFilter
- * \brief Data Filter based on Octree representation
+ * \brief Data Filter based on Octree/Quadtree representation
  *
  * \author Mathieu Labussiere (<mathieu dot labu at gmail dot com>)
  * \date 24/05/2018
@@ -89,7 +89,6 @@ struct OctreeGridDataPointsFilter : public PointMatcher<T>::DataPointsFilter
 
 public:
 //Visitors class to apply processing
-	template<template<typename> typename Tree>
 	struct FirstPtsSampler
 	{
 		std::size_t idx;
@@ -101,16 +100,19 @@ public:
 
 		FirstPtsSampler(DataPoints& dp);
 		virtual ~FirstPtsSampler(){}
-		virtual bool operator()(Tree<T>& oc);
+		
+		template<template<typename> typename Tree>
+		bool operator()(Tree<T>& oc);
+		
 		virtual bool finalize();
 	};
 	
-	template<template<typename> typename Tree>
-	struct RandomPtsSampler : public FirstPtsSampler<Tree>
+	
+	struct RandomPtsSampler : public FirstPtsSampler
 	{
-		using FirstPtsSampler<Tree>::idx;
-		using FirstPtsSampler<Tree>::pts;
-		using FirstPtsSampler<Tree>::mapidx;
+		using FirstPtsSampler::idx;
+		using FirstPtsSampler::pts;
+		using FirstPtsSampler::mapidx;
 		
 		const std::size_t seed;
 	
@@ -118,32 +120,26 @@ public:
 		RandomPtsSampler(DataPoints& dp, const std::size_t seed_);
 		virtual ~RandomPtsSampler(){}
 	
-		virtual bool operator()(Tree<T>& oc);
+		template<template<typename> typename Tree>
+		bool operator()(Tree<T>& oc);
+		
 		virtual bool finalize();
 	};
 	
-	template<template<typename> typename Tree>
-	struct CentroidSampler : public FirstPtsSampler<Tree>
+	struct CentroidSampler : public FirstPtsSampler
 	{
-		using FirstPtsSampler<Tree>::idx;
-		using FirstPtsSampler<Tree>::pts;
-		using FirstPtsSampler<Tree>::mapidx;
+		using FirstPtsSampler::idx;
+		using FirstPtsSampler::pts;
+		using FirstPtsSampler::mapidx;
 		
 		CentroidSampler(DataPoints& dp);
 	
 		virtual ~CentroidSampler(){}
 	
-		virtual bool operator()(Tree<T>& oc);
+		template<template<typename> typename Tree>
+		bool operator()(Tree<T>& oc);
 	};
 
-//Aliases
-	using FirstPtsSampler3D = FirstPtsSampler<Octree>;
-	using RandomPtsSampler3D = FirstPtsSampler<Octree>;
-	using CentroidSampler3D = FirstPtsSampler<Octree>;
-	using FirstPtsSampler2D = FirstPtsSampler<Quadtree>;
-	using RandomPtsSampler2D = FirstPtsSampler<Quadtree>;
-	using CentroidSampler2D = FirstPtsSampler<Quadtree>;
-	
 //-------	
 	enum BuildMethod : int { MAX_POINT=0, MAX_SIZE=1 }; 
 	enum SamplingMethod : int { FIRST_PTS=0, RAND_PTS=1, CENTROID=2 };

--- a/pointmatcher/DataPointsFilters/utils/octree.h
+++ b/pointmatcher/DataPointsFilters/utils/octree.h
@@ -48,7 +48,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Octree implementation for decomposing point cloud. 
  * The current implementation use the data structure PointMatcher<T>::DataPoints. 
- * It ensures that each node has either 8 or 0 childs. 
+ * It ensures that each node has either 8 or 0 childrend. 
  *
  * Can create an octree with the 2 following crieterions:
  *	- max number of data by node
@@ -79,35 +79,35 @@ public:
 	using Data = typename DP::Index; /**/
 	using DataContainer = std::vector<Data>;
 
-private:
-	struct XYZ 
+	struct Point 
 	{
 		T x;
 		T y;
 		T z;
 		
-		XYZ(T x_=T(0.0), T y_=T(0.0), T z_=T(0.0)) : x{x_}, y{y_}, z{z_} {}
+		Point(T x_=T(0.0), T y_=T(0.0), T z_=T(0.0)) : x{x_}, y{y_}, z{z_} {}
 	
-		void operator+=(const XYZ& v){ x+=v.x; y+=v.y; z+=v.z; }
-		void operator-=(const XYZ& v){ x-=v.x; y-=v.y; z-=v.z; }
-		void operator*=(const XYZ& v){ x*=v.x; y*=v.y; z*=v.z; }
+		void operator+=(const Point& v){ x+=v.x; y+=v.y; z+=v.z; }
+		void operator-=(const Point& v){ x-=v.x; y-=v.y; z-=v.z; }
+		void operator*=(const Point& v){ x*=v.x; y*=v.y; z*=v.z; }
 		void operator*=(const T& s){ x*=s; y*=s; z*=s; }
 		void operator/=(const T& s){ x/=s; y/=s; z/=s; }
 		
-		XYZ operator+(const XYZ& v2){return XYZ{x+v2.x,y+v2.y,z+v2.z};}
-		XYZ operator-(const XYZ& v2){return XYZ{x-v2.x,y-v2.y,z-v2.z};}
-		XYZ operator*(const XYZ& v2){return XYZ{x*v2.x,y*v2.y,z*v2.z};}
-		XYZ operator*(const T& s)   {return XYZ{s*x,s*y,s*z};}
-		XYZ operator/(const XYZ& v2){return XYZ{x/v2.x,y/v2.y,z/v2.z};}
-		XYZ operator/(const T& s)   {return XYZ{s/x,s/y,s/z};}
+		Point operator+(const Point& v2){return Point{x+v2.x,y+v2.y,z+v2.z};}
+		Point operator-(const Point& v2){return Point{x-v2.x,y-v2.y,z-v2.z};}
+		Point operator*(const Point& v2){return Point{x*v2.x,y*v2.y,z*v2.z};}
+		Point operator*(const T& s)   {return Point{s*x,s*y,s*z};}
+		Point operator/(const Point& v2){return Point{x/v2.x,y/v2.y,z/v2.z};}
+		Point operator/(const T& s)   {return Point{s/x,s/y,s/z};}
 	};
 	
 	struct BoundingBox 
 	{
-			XYZ center;
+			Point center;
 			T 	radius;
 	};
-	
+
+protected:	
 	Octree* parent;
 	Octree* octants[8];
 	
@@ -143,7 +143,7 @@ public:
 	bool isEmpty()const;
 	
 	
-	inline std::size_t idx(const XYZ& xyz) const;
+	inline std::size_t idx(const Point& xyz) const;
 	inline std::size_t idx(T x, T y, T z) const;
 	
 	inline std::size_t getDepth() const;

--- a/pointmatcher/DataPointsFilters/utils/octree.hpp
+++ b/pointmatcher/DataPointsFilters/utils/octree.hpp
@@ -86,7 +86,7 @@ Octree<T>::Octree(Octree<T>&& o):
 			std::make_move_iterator(o.data.end()));
 	}
 	
-	//copy child ptr
+	//copy children ptr
 	for(size_t i=0; i<8; ++i)
 	{
 		octants[i] = o.octants[i];
@@ -219,7 +219,7 @@ Octree<T>* Octree<T>::operator[](size_t idx)
 #define TO_DATA(pts_, ids_) ([](const DP& pts, const std::vector<Id>& ids) -> DataContainer \
 		{ return DataContainer{ids.begin(), ids.end()}; })(pts_, ids_)
 						
-#define TO_POINT(pts, d) pts.features(0,d),pts.features(1,d),pts.features(2,d)
+#define TO_XYZ(pts, d) pts.features(0,d),pts.features(1,d),pts.features(2,d)
 
 // Build tree from DataPoints with a specified number of points by node
 template< typename T >
@@ -299,7 +299,7 @@ bool Octree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb, s
 	for(auto&& d : datas)
 	{
 		//FIXME: Should be a generic conversion from DataPoint considering Data to Point
-		(sDatas[idx( TO_POINT(pts,d) )]).emplace_back(d);
+		(sDatas[idx( TO_XYZ(pts,d) )]).emplace_back(d);
 	}
 	
 	for(size_t i=0; i<8; ++i)
@@ -320,6 +320,7 @@ bool Octree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb, s
 	for(size_t i=0; i<8; ++i)
 	{
 		octants[i] = new Octree<T>();
+		//Assign depth
 		octants[i]->depth = this->depth+1;
 		ret = ret and octants[i]->build(pts, std::move(sDatas[i]), std::move(boxes[i]), maxDataByNode);		
 		//Assign parent
@@ -368,7 +369,7 @@ bool Octree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox && b
 	for(auto&& d : datas)
 	{
 		//FIXME: Should be a generic conversion from DataPoint considering Data to Point
-		(sDatas[idx( TO_POINT(pts,d) )]).emplace_back(d);
+		(sDatas[idx( TO_XYZ(pts,d) )]).emplace_back(d);
 	}
 	
 	for(size_t i=0; i<8; ++i)
@@ -484,7 +485,7 @@ bool Octree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb, T
 	for(auto&& d : datas)
 	{
 		//FIXME: Should be a generic conversion from DataPoint considering Data to Point
-		(sDatas[idx( TO_POINT(pts,d) )]).emplace_back(d);
+		(sDatas[idx( TO_XYZ(pts,d) )]).emplace_back(d);
 	}
 	
 	for(size_t i=0; i<8; ++i)
@@ -505,6 +506,7 @@ bool Octree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb, T
 	for(size_t i=0; i<8; ++i)
 	{
 		octants[i] = new Octree<T>();
+		//Assign depth
 		octants[i]->depth = this->depth+1;	
 		ret = ret and octants[i]->build(pts, std::move(sDatas[i]), std::move(boxes[i]), maxSizeByNode);		
 		//Assign parent
@@ -529,7 +531,7 @@ bool Octree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox && b
 			Point{+0.5, +0.5, +0.5}
 		};
 	
-	//Check maxData count
+	//Check bounding box size or if there is data
 	if((bb.radius*2.0 <= maxSizeByNode) or (datas.size() <= 1))
 	{			
 		//insert data
@@ -552,7 +554,7 @@ bool Octree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox && b
 	for(auto&& d : datas)
 	{
 		//FIXME: Should be a generic conversion from DataPoint considering Data to Point
-		(sDatas[idx( TO_POINT(pts,d) )]).emplace_back(d);
+		(sDatas[idx( TO_XYZ(pts,d) )]).emplace_back(d);
 	}
 	
 	for(size_t i=0; i<8; ++i)

--- a/pointmatcher/DataPointsFilters/utils/quadtree.h
+++ b/pointmatcher/DataPointsFilters/utils/quadtree.h
@@ -48,7 +48,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Quadtree implementation for decomposing point cloud. 
  * The current implementation use the data structure PointMatcher<T>::DataPoints. 
- * It ensures that each node has either 4 or 0 childs. 
+ * It ensures that each node has either 4 or 0 children. 
  *
  * Can create an quadtree with the 2 following crieterions:
  *	- max number of data by node
@@ -79,34 +79,34 @@ public:
 	using Data = typename DP::Index; /**/
 	using DataContainer = std::vector<Data>;
 
-private:
-	struct XY
+	struct Point
 	{
 		T x;
 		T y;
 		
-		XY(T x_=T(0.0), T y_=T(0.0)) : x{x_}, y{y_} {}
+		Point(T x_=T(0.0), T y_=T(0.0)) : x{x_}, y{y_} {}
 	
-		void operator+=(const XY& v){ x+=v.x; y+=v.y;}
-		void operator-=(const XY& v){ x-=v.x; y-=v.y;}
-		void operator*=(const XY& v){ x*=v.x; y*=v.y;}
+		void operator+=(const Point& v){ x+=v.x; y+=v.y;}
+		void operator-=(const Point& v){ x-=v.x; y-=v.y;}
+		void operator*=(const Point& v){ x*=v.x; y*=v.y;}
 		void operator*=(const T& s) { x*=s; y*=s;}
 		void operator/=(const T& s) { x/=s; y/=s;}
 		
-		XY operator+(const XY& v2){return XY{x+v2.x,y+v2.y};}
-		XY operator-(const XY& v2){return XY{x-v2.x,y-v2.y};}
-		XY operator*(const XY& v2){return XY{x*v2.x,y*v2.y};}
-		XY operator*(const T& s)  {return XY{s*x,s*y};}
-		XY operator/(const XY& v2){return XY{x/v2.x,y/v2.y};}
-		XY operator/(const T& s)  {return XY{s/x,s/y};}
+		Point operator+(const Point& v2){return Point{x+v2.x,y+v2.y};}
+		Point operator-(const Point& v2){return Point{x-v2.x,y-v2.y};}
+		Point operator*(const Point& v2){return Point{x*v2.x,y*v2.y};}
+		Point operator*(const T& s)  {return Point{s*x,s*y};}
+		Point operator/(const Point& v2){return Point{x/v2.x,y/v2.y};}
+		Point operator/(const T& s)  {return Point{s/x,s/y};}
 	};
 	
 	struct BoundingBox 
 	{
-			XY center;
+			Point center;
 			T 	radius;
 	};
-	
+
+protected:	
 	Quadtree* parent;
 	Quadtree* cells[4];
 	
@@ -140,7 +140,7 @@ public:
 	bool isRoot() const;
 	bool isEmpty()const;
 	
-	inline std::size_t idx(const XY& xy) const;
+	inline std::size_t idx(const Point& xy) const;
 	inline std::size_t idx(T x, T y) const;
 	
 	inline std::size_t getDepth() const;

--- a/pointmatcher/DataPointsFilters/utils/quadtree.h
+++ b/pointmatcher/DataPointsFilters/utils/quadtree.h
@@ -1,0 +1,164 @@
+// kate: replace-tabs off; indent-width 4; indent-mode normal
+// vim: ts=4:sw=4:noexpandtab
+/*
+
+Copyright (c) 2010--2018,
+François Pomerleau and Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the authors at <f dot pomerleau at gmail dot com> and
+<stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#pragma once
+
+#include <cstdlib> 
+#include <vector>
+#include "PointMatcher.h"
+
+/*!
+ * \class quadtree.h
+ * \brief Quadtree class for 2D DataPoints spatial representation
+ *
+ * \author Mathieu Labussiere (<mathieu dot labu at gmail dot com>)
+ * \date 31/05/2018
+ * \version 0.1
+ *
+ * Quadtree implementation for decomposing point cloud. 
+ * The current implementation use the data structure PointMatcher<T>::DataPoints. 
+ * It ensures that each node has either 4 or 0 childs. 
+ *
+ * Can create an quadtree with the 2 following crieterions:
+ *	- max number of data by node
+ *	- max size of a node (or stop when only one or zero data element is available)
+ *
+ * After construction, we can apply a process by creating a Visitor, implementing the following method:
+ *	```cpp
+ *	template<typename T>
+ *	struct Visitor {
+ *		bool operator()(Quadtree<T>& oc);
+ *	};
+ *	```
+ *
+ * Remark:
+ *	- Current implementation only store the indexes of the points from the pointcloud.
+ *	- Data element are exclusively contained in leaves node.
+ *	- Some leaves node contains no data (to ensure 4 or 0 childs).
+ *
+ */
+template < typename T >
+class Quadtree 
+{
+public:
+	using PM = PointMatcher<T>;
+	using DP = typename PM::DataPoints; /**/
+	using Id = typename DP::Index; /**/
+	
+	using Data = typename DP::Index; /**/
+	using DataContainer = std::vector<Data>;
+
+private:
+	struct XY
+	{
+		T x;
+		T y;
+		
+		XY(T x_=T(0.0), T y_=T(0.0)) : x{x_}, y{y_} {}
+	
+		void operator+=(const XY& v){ x+=v.x; y+=v.y;}
+		void operator-=(const XY& v){ x-=v.x; y-=v.y;}
+		void operator*=(const XY& v){ x*=v.x; y*=v.y;}
+		void operator*=(const T& s) { x*=s; y*=s;}
+		void operator/=(const T& s) { x/=s; y/=s;}
+		
+		XY operator+(const XY& v2){return XY{x+v2.x,y+v2.y};}
+		XY operator-(const XY& v2){return XY{x-v2.x,y-v2.y};}
+		XY operator*(const XY& v2){return XY{x*v2.x,y*v2.y};}
+		XY operator*(const T& s)  {return XY{s*x,s*y};}
+		XY operator/(const XY& v2){return XY{x/v2.x,y/v2.y};}
+		XY operator/(const T& s)  {return XY{s/x,s/y};}
+	};
+	
+	struct BoundingBox 
+	{
+			XY center;
+			T 	radius;
+	};
+	
+	Quadtree* parent;
+	Quadtree* cells[4];
+	
+	/******************************************************
+	 *	Cell id are assigned as their position 
+	 *   on a hamming square (+ greater than center, - lower than center)
+	 *
+	 *	  	0	1	2	3
+	 * 	x:	-	+	-	+
+	 * 	y:	-	-	+	+
+	 *
+	 *****************************************************/
+	
+	BoundingBox bb;
+	
+	DataContainer data;	
+	
+	std::size_t depth;
+	
+public:
+	Quadtree();
+	Quadtree(const Quadtree<T>& o); //Deep-copy
+	Quadtree(Quadtree<T>&&o);
+	
+	virtual ~Quadtree();
+	
+	Quadtree<T>& operator=(const Quadtree<T>&o); //Deep-copy
+	Quadtree<T>& operator=(Quadtree<T>&& o);
+	
+	bool isLeaf() const;
+	bool isRoot() const;
+	bool isEmpty()const;
+	
+	inline std::size_t idx(const XY& xy) const;
+	inline std::size_t idx(T x, T y) const;
+	
+	inline std::size_t getDepth() const;
+	DataContainer * getData();
+	Quadtree<T>* operator[](std::size_t idx);
+	
+	// Build tree from DataPoints with a specified number of points by node
+	bool build(const DP& pts, std::size_t maxDataByNode, bool parallel_build=false);
+	bool build_par(const DP& pts, DataContainer&& datas, BoundingBox && bb, std::size_t maxDataByNode);
+	bool build(const DP& pts, DataContainer&& datas, BoundingBox && bb, std::size_t maxDataByNode);
+	
+	// Build tree from DataPoints with a specified max size by node
+	bool build(const DP& pts, T maxSizeByNode, bool parallel_build=false);
+	bool build_par(const DP& pts, DataContainer&& datas, BoundingBox && bb, T maxSizeByNode);
+	bool build(const DP& pts, DataContainer&& datas, BoundingBox && bb, T maxSizeByNode);
+	
+	template < typename Callback >
+	bool visit(Callback& cb);
+};
+
+#include "quadtree.hpp"

--- a/pointmatcher/DataPointsFilters/utils/quadtree.hpp
+++ b/pointmatcher/DataPointsFilters/utils/quadtree.hpp
@@ -1,0 +1,588 @@
+// kate: replace-tabs off; indent-width 4; indent-mode normal
+// vim: ts=4:sw=4:noexpandtab
+/*
+
+Copyright (c) 2010--2018,
+François Pomerleau and Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the authors at <f dot pomerleau at gmail dot com> and
+<stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include "quadtree.h"
+
+#include <iterator>
+
+template< typename T >
+Quadtree<T>::Quadtree()
+	: parent{nullptr}, 
+		cells{nullptr,nullptr,nullptr,nullptr},
+		depth{0}
+{
+}
+
+template< typename T >
+Quadtree<T>::Quadtree(const Quadtree<T>& o)
+	: bb{o.bb.center, o.bb.radius}, depth{o.depth}
+{
+	if (!o.parent) parent = nullptr;	
+	if(o.isLeaf()) //Leaf case
+	{
+		//nullify childs
+		for(size_t i=0; i<4; ++i)
+			cells[i]= nullptr;
+		//Copy data
+		data.insert(data.end(), o.data.begin(), o.data.end());
+	}
+	else //Node case
+	{
+		//Create each child recursively
+  	for(size_t i=0; i<4;++i)
+  	{
+  		cells[i] = new Quadtree<T>(*(o.cells[i]));	
+			//Assign parent  	
+  		cells[i]->parent = this;
+  	}
+  	//no data in node to copy 	
+	}
+}
+
+template< typename T >
+Quadtree<T>::Quadtree(Quadtree<T>&& o)
+	: parent{nullptr}, bb{o.bb.center, o.bb.radius}, depth{o.depth}
+{
+	//only allow move of root node
+	assert(o.isRoot());
+	
+	if(o.isLeaf()) //Leaf case
+	{
+		//Copy data
+		data.insert(data.end(), 
+			std::make_move_iterator(o.data.begin()), 
+			std::make_move_iterator(o.data.end()));
+	}
+	
+	//copy child ptr
+	for(size_t i=0; i<4; ++i)
+	{
+		cells[i] = o.cells[i];
+		//Nullify ptrs
+		o.cells[i]=nullptr;
+	}
+}
+
+template< typename T >
+Quadtree<T>::~Quadtree()
+{	
+	//delete recursively childs
+	if(!isLeaf())
+		for(size_t i=0; i<4; ++i)
+			delete cells[i];
+}
+
+template< typename T >	
+Quadtree<T>& Quadtree<T>::operator=(const Quadtree<T>&o)
+{
+	if (!o.parent) parent = nullptr;
+	depth=o.depth;
+	
+	if(o.isLeaf()) //Leaf case
+	{
+		//nullify childs
+		for(size_t i=0; i<4; ++i)
+			cells[i]= nullptr;
+		//Copy data
+		data.insert(data.end(), o.data.begin(), o.data.end());
+	}
+	else //Node case
+	{
+		//Create each child recursively
+		for(size_t i=0; i<4; ++i)
+		{
+			cells[i] = new Quadtree<T>(*(o.cells[i]));	
+			//Assign parent  	
+			cells[i]->parent = this;
+		}
+		//no data in node to copy 	
+	}
+	return *this;
+}
+
+template< typename T >	
+Quadtree<T>& Quadtree<T>::operator=(Quadtree<T>&&o)
+{
+	//only allow move of root node
+	assert(o.isRoot());
+	
+	parent = nullptr;
+	bb.center = o.bb.center;
+	bb.radius = o.bb.radius;
+	
+	depth = o.depth;
+	
+	if(o.isLeaf()) //Leaf case
+	{
+		//Copy data
+		data.insert(data.end(), 
+			std::make_move_iterator(o.data.begin()), 
+			std::make_move_iterator(o.data.end()));
+	}
+	
+	//copy childs ptrs
+	for(size_t i=0; i<4; ++i)
+	{
+		cells[i] = o.cells[i];
+		//Nullify ptrs
+		o.cells[i]=nullptr;
+	}
+	
+	return *this;
+}
+
+template< typename T >
+bool Quadtree<T>::isLeaf() const
+{
+	return (cells[0]==nullptr);
+}
+template< typename T >
+bool Quadtree<T>::isRoot() const
+{
+	return (parent==nullptr);
+}
+template< typename T >
+bool Quadtree<T>::isEmpty() const
+{
+	return (data.size() == 0);
+}
+template< typename T >
+size_t Quadtree<T>::idx(const XY& xy) const
+{
+	size_t id = 0;
+	id|= ((xy.x > bb.center.x) << 0);
+	id|= ((xy.y > bb.center.y) << 1);
+	return id;
+}
+template< typename T >
+size_t Quadtree<T>::idx(T x, T y) const
+{
+	size_t id = 0;
+	id|= ((x > bb.center.x) << 0);
+	id|= ((y > bb.center.y) << 1);
+	return id;
+}
+template< typename T >
+size_t Quadtree<T>::getDepth() const
+{
+	return depth;
+}
+template< typename T >
+typename Quadtree<T>::DataContainer * Quadtree<T>::getData()
+{
+	return &data;
+}
+template< typename T >
+Quadtree<T>* Quadtree<T>::operator[](size_t idx)
+{
+	assert(idx<4);
+	return cells[idx];
+}
+
+
+#define TO_DATA(pts_, ids_) ([](const DP& pts, const std::vector<Id>& ids) -> DataContainer \
+		{ return DataContainer{ids.begin(), ids.end()}; })(pts_, ids_)
+						
+#define TO_XY(pts, d) pts.features(0,d),pts.features(1,d)
+
+// Build tree from DataPoints with a specified number of points by node
+template< typename T >
+bool Quadtree<T>::build(const DP& pts, size_t maxDataByNode, bool parallel_build)
+{
+	typedef typename PM::Vector Vector;
+	
+	//Build bounding box
+	BoundingBox box;
+	
+	Vector minValues = pts.features.rowwise().minCoeff();
+	XY min{minValues(0), minValues(1)};
+	Vector maxValues = pts.features.rowwise().maxCoeff();
+	XY max{maxValues(0), maxValues(1)};
+	
+	XY radii = max - min;
+	box.center = min + radii * 0.5;
+	box.radius = radii.x;
+	if (box.radius < radii.y) box.radius = radii.y;
+	
+	//Transform pts in data
+	const size_t nbpts = pts.getNbPoints();
+	std::vector<Id> indexes;
+	indexes.reserve(nbpts);
+		
+	for(size_t i=0; i<nbpts; ++i)
+		indexes.emplace_back(Id(i));
+	
+	//FIXME: should be a generic conversion from DP to DataContainer 
+	DataContainer datas = TO_DATA(pts, indexes);
+	
+	//build
+	bool ret = true;
+	if(parallel_build) 
+		ret = this->build_par(pts, std::move(datas), std::move(box), maxDataByNode);
+	else 
+		ret = this->build(pts, std::move(datas), std::move(box), maxDataByNode);
+
+	return ret;
+}
+
+template< typename T >
+bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb, size_t maxDataByNode)
+{
+	static XY offsetTable[4] =
+		{
+			XY{-0.5, -0.5},
+			XY{-0.5, +0.5},
+			XY{+0.5, -0.5},
+			XY{+0.5, +0.5}
+		};
+	//Check maxData count
+	if(datas.size() <= maxDataByNode)
+	{	
+		//insert data
+		data.insert(data.end(), 
+			std::make_move_iterator(datas.begin()), make_move_iterator(datas.end()));
+		return (isLeaf());
+	}
+	
+	//Assign bounding box
+	this->bb.center = bb.center;
+	this->bb.radius = bb.radius;
+	
+	//Split datas
+	const std::size_t nbData = datas.size();
+	
+	DataContainer sDatas[4];
+	for(size_t i=0; i<4; ++i)
+		sDatas[i].reserve(nbData);
+		
+	for(auto&& d : datas)
+	{
+		//FIXME: Should be a generic conversion from DataPoint considering Data to XY
+		(sDatas[idx( TO_XY(pts,d) )]).emplace_back(d);
+	}
+	
+	for(size_t i=0; i<4; ++i)
+		sDatas[i].shrink_to_fit();
+	
+	//Compute new bounding boxes
+	BoundingBox boxes[4];
+	const T half_radius = this->bb.radius * 0.5;
+	for(size_t i=0; i<4; ++i)
+	{
+		const XY offset = offsetTable[i] * this->bb.radius;
+		boxes[i].radius = half_radius;
+		boxes[i].center = this->bb.center + offset;
+	}
+	
+	//For each child build recursively
+	bool ret = true;
+	for(size_t i=0; i<4; ++i)
+	{
+		cells[i] = new Quadtree<T>();
+		cells[i]->depth = this->depth+1;
+		ret = ret and cells[i]->build(pts, std::move(sDatas[i]), std::move(boxes[i]), maxDataByNode);		
+		//Assign parent
+		cells[i]->parent = this;
+	}
+
+	return (!isLeaf() and ret);
+}
+
+#include <thread>
+template< typename T >
+bool Quadtree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox && bb, size_t maxDataByNode)
+{
+	static XY offsetTable[4] =
+		{
+			XY{-0.5, -0.5},
+			XY{-0.5, +0.5},
+			XY{+0.5, -0.5},
+			XY{+0.5, +0.5}
+		};
+	
+	//Check maxData count
+	if(datas.size() <= maxDataByNode)
+	{			
+		//insert data
+		data.insert(data.end(), 
+			std::make_move_iterator(datas.begin()), make_move_iterator(datas.end()));
+		return (isLeaf());
+	}
+	
+	//Assign bounding box
+	this->bb.center = bb.center;
+	this->bb.radius = bb.radius;
+	
+	//Split datas
+	const std::size_t nbData = datas.size();
+	
+	DataContainer sDatas[4];
+	for(size_t i=0; i<4; ++i)
+		sDatas[i].reserve(nbData);
+		
+	for(auto&& d : datas)
+	{
+		//FIXME: Should be a generic conversion from DataPoint considering Data to XY
+		(sDatas[idx( TO_XY(pts,d) )]).emplace_back(d);
+	}
+	
+	for(size_t i=0; i<4; ++i)
+		sDatas[i].shrink_to_fit();
+	
+	//Compute new bounding boxes
+	BoundingBox boxes[4];
+	const T half_radius = this->bb.radius * 0.5;
+	for(size_t i=0; i<4; ++i)
+	{
+		const XY offset = offsetTable[i] * this->bb.radius;
+		boxes[i].radius = half_radius;
+		boxes[i].center = this->bb.center + offset;
+	}
+	
+	//Parallely build each child recursively	
+	std::vector<std::thread> threads;
+	bool ret = true;
+	for(size_t i=0; i<4; ++i)
+	{
+		threads.push_back( std::thread( [maxDataByNode, i, &pts, &sDatas, &boxes, this](){
+			this->cells[i] = new Quadtree<T>();
+			//Assign depth
+			this->cells[i]->depth = this->depth+1;	
+			//Assign parent
+			this->cells[i]->parent = this;
+			this->cells[i]->build(pts, std::move(sDatas[i]), std::move(boxes[i]), maxDataByNode);	
+		}));
+	}
+	
+	// Wait for all thread to finish
+	for (std::thread & t : threads)
+		if (t.joinable()) t.join();
+		
+	return (!isLeaf() and ret);
+}
+
+//------------------------------------------------------------------------------
+template< typename T >
+bool Quadtree<T>::build(const DP& pts, T maxSizeByNode, bool parallel_build)
+{
+	typedef typename PM::Vector Vector;
+	
+	//Build bounding box
+	BoundingBox box;
+	
+	Vector minValues = pts.features.rowwise().minCoeff();
+	XY min{minValues(0), minValues(1)};
+	Vector maxValues = pts.features.rowwise().maxCoeff();
+	XY max{maxValues(0), maxValues(1)};
+	
+	XY radii = max - min;
+	box.center = min + radii * 0.5;
+	box.radius = radii.x;
+	if (box.radius < radii.y) box.radius = radii.y;
+	
+	//Transform pts in data
+	const size_t nbpts = pts.getNbPoints();
+	std::vector<Id> indexes;
+	indexes.reserve(nbpts);
+	
+	for(size_t i=0; i<nbpts; ++i)
+		indexes.emplace_back(Id(i));
+	
+	//FIXME: should be a generic conversion from DP to DataContainer 
+	DataContainer datas = TO_DATA(pts, indexes);
+	
+	//build
+	bool ret = true;
+	if(parallel_build) 
+		ret = this->build_par(pts, std::move(datas), std::move(box), maxSizeByNode);
+	else 
+		ret = this->build(pts, std::move(datas), std::move(box), maxSizeByNode);
+
+	return ret;
+}
+
+template< typename T >
+bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb, T maxSizeByNode)
+{
+	static XY offsetTable[4] =
+		{
+			XY{-0.5, -0.5},
+			XY{-0.5, +0.5},
+			XY{+0.5, -0.5},
+			XY{+0.5, +0.5}
+		};
+	//Check maxData count
+	if((bb.radius*2.0 <= maxSizeByNode) or (datas.size() <= 1))
+	{
+		//insert data
+		data.insert(data.end(), 
+			std::make_move_iterator(datas.begin()), make_move_iterator(datas.end()));
+		return (isLeaf());
+	}
+	
+	//Assign bounding box
+	this->bb.center = bb.center;
+	this->bb.radius = bb.radius;
+	
+	//Split datas
+	const std::size_t nbData = datas.size();
+	
+	DataContainer sDatas[4];
+	for(size_t i=0; i<4; ++i)
+		sDatas[i].reserve(nbData);
+		
+	for(auto&& d : datas)
+	{
+		//FIXME: Should be a generic conversion from DataPoint considering Data to XY
+		(sDatas[idx( TO_XY(pts,d) )]).emplace_back(d);
+	}
+	
+	for(size_t i=0; i<4; ++i)
+		sDatas[i].shrink_to_fit();
+	
+	//Compute new bounding boxes
+	BoundingBox boxes[4];
+	const T half_radius = this->bb.radius * 0.5;
+	for(size_t i=0; i<4; ++i)
+	{
+		const XY offset = offsetTable[i] * this->bb.radius;
+		boxes[i].radius = half_radius;
+		boxes[i].center = this->bb.center + offset;
+	}
+	
+	//For each child build recursively
+	bool ret = true;
+	for(size_t i=0; i<4; ++i)
+	{
+		cells[i] = new Quadtree<T>();
+		cells[i]->depth = this->depth+1;	
+		ret = ret and cells[i]->build(pts, std::move(sDatas[i]), std::move(boxes[i]), maxSizeByNode);		
+		//Assign parent
+		cells[i]->parent = this;
+	}
+
+	return (!isLeaf() and ret);
+}
+
+template< typename T >
+bool Quadtree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox && bb, T maxSizeByNode)
+{
+	static XY offsetTable[4] =
+		{
+			XY{-0.5, -0.5},
+			XY{-0.5, +0.5},
+			XY{+0.5, -0.5},
+			XY{+0.5, +0.5}
+		};
+	
+	//Check maxData count
+	if((bb.radius*2.0 <= maxSizeByNode) or (datas.size() <= 1))
+	{			
+		//insert data
+		data.insert(data.end(), 
+			std::make_move_iterator(datas.begin()), make_move_iterator(datas.end()));
+		return (isLeaf());
+	}
+	
+	//Assign bounding box
+	this->bb.center = bb.center;
+	this->bb.radius = bb.radius;
+	
+	//Split datas
+	const std::size_t nbData = datas.size();
+	
+	DataContainer sDatas[4];
+	for(size_t i=0; i<4; ++i)
+		sDatas[i].reserve(nbData);
+		
+	for(auto&& d : datas)
+	{
+		//FIXME: Should be a generic conversion from DataPoint considering Data to XY
+		(sDatas[idx( TO_XY(pts,d) )]).emplace_back(d);
+	}
+	
+	for(size_t i=0; i<4; ++i)
+		sDatas[i].shrink_to_fit();
+	
+	//Compute new bounding boxes
+	BoundingBox boxes[4];
+	const T half_radius = this->bb.radius * 0.5;
+	for(size_t i=0; i<4; ++i)
+	{
+		const XY offset = offsetTable[i] * this->bb.radius;
+		boxes[i].radius = half_radius;
+		boxes[i].center = this->bb.center + offset;
+	}
+	
+	//For each child build recursively	
+	std::vector<std::thread> threads;
+	bool ret = true;
+	for(size_t i=0; i<4; ++i)
+	{
+		threads.push_back( std::thread( [maxSizeByNode, i, &pts, &sDatas, &boxes, this](){
+			this->cells[i] = new Quadtree<T>();
+			//Assign depth
+			this->cells[i]->depth = this->depth+1;	
+			//Assign parent
+			this->cells[i]->parent = this;
+			this->cells[i]->build(pts, std::move(sDatas[i]), std::move(boxes[i]), maxSizeByNode);	
+		}));
+	}
+	
+	// Wait for all thread to finish
+	for (std::thread & t : threads)
+		if (t.joinable()) t.join();
+		
+	return (!isLeaf() and ret);
+}
+
+//------------------------------------------------------------------------------
+template< typename T >
+template< typename Callback >
+bool Quadtree<T>::visit(Callback& cb)
+{
+	// Call the callback for this node (if the callback returns false, then
+	// stop traversing.
+	if (!cb(*this)) return false;
+
+	// If I'm a node, recursively traverse my children
+	if (!isLeaf())
+		for (size_t i=0; i<4; ++i)
+			if (!cells[i]->visit(cb)) return false;
+
+	return true;
+}
+
+template class Quadtree<float>;
+template class Quadtree<double>;

--- a/pointmatcher/DataPointsFilters/utils/quadtree.hpp
+++ b/pointmatcher/DataPointsFilters/utils/quadtree.hpp
@@ -262,8 +262,8 @@ bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb,
 	static XY offsetTable[4] =
 		{
 			XY{-0.5, -0.5},
-			XY{-0.5, +0.5},
 			XY{+0.5, -0.5},
+			XY{-0.5, +0.5},
 			XY{+0.5, +0.5}
 		};
 	//Check maxData count
@@ -326,8 +326,8 @@ bool Quadtree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox &&
 	static XY offsetTable[4] =
 		{
 			XY{-0.5, -0.5},
-			XY{-0.5, +0.5},
 			XY{+0.5, -0.5},
+			XY{-0.5, +0.5},
 			XY{+0.5, +0.5}
 		};
 	
@@ -438,8 +438,8 @@ bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb,
 	static XY offsetTable[4] =
 		{
 			XY{-0.5, -0.5},
-			XY{-0.5, +0.5},
 			XY{+0.5, -0.5},
+			XY{-0.5, +0.5},
 			XY{+0.5, +0.5}
 		};
 	//Check maxData count
@@ -501,8 +501,8 @@ bool Quadtree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox &&
 	static XY offsetTable[4] =
 		{
 			XY{-0.5, -0.5},
-			XY{-0.5, +0.5},
 			XY{+0.5, -0.5},
+			XY{-0.5, +0.5},
 			XY{+0.5, +0.5}
 		};
 	

--- a/pointmatcher/DataPointsFilters/utils/quadtree.hpp
+++ b/pointmatcher/DataPointsFilters/utils/quadtree.hpp
@@ -37,21 +37,21 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iterator>
 
 template< typename T >
-Quadtree<T>::Quadtree()
-	: parent{nullptr}, 
-		cells{nullptr,nullptr,nullptr,nullptr},
-		depth{0}
+Quadtree<T>::Quadtree(): parent{nullptr}, 
+    cells{nullptr,nullptr,nullptr,nullptr}, depth{0}
 {
 }
 
 template< typename T >
-Quadtree<T>::Quadtree(const Quadtree<T>& o)
-	: bb{o.bb.center, o.bb.radius}, depth{o.depth}
+Quadtree<T>::Quadtree(const Quadtree<T>& o): 
+    bb{o.bb.center, o.bb.radius}, depth{o.depth}
 {
-	if (!o.parent) parent = nullptr;	
+	if (!o.parent) 
+	    parent = nullptr;
+	    	
 	if(o.isLeaf()) //Leaf case
 	{
-		//nullify childs
+		//nullify children
 		for(size_t i=0; i<4; ++i)
 			cells[i]= nullptr;
 		//Copy data
@@ -60,19 +60,19 @@ Quadtree<T>::Quadtree(const Quadtree<T>& o)
 	else //Node case
 	{
 		//Create each child recursively
-  	for(size_t i=0; i<4;++i)
-  	{
-  		cells[i] = new Quadtree<T>(*(o.cells[i]));	
+		for(size_t i=0; i<4;++i)
+		{
+			cells[i] = new Quadtree<T>(*(o.cells[i]));	
 			//Assign parent  	
-  		cells[i]->parent = this;
-  	}
-  	//no data in node to copy 	
+			cells[i]->parent = this;
+		}
+		//no data in node to copy 	
 	}
 }
 
 template< typename T >
-Quadtree<T>::Quadtree(Quadtree<T>&& o)
-	: parent{nullptr}, bb{o.bb.center, o.bb.radius}, depth{o.depth}
+Quadtree<T>::Quadtree(Quadtree<T>&& o): 
+		parent{nullptr}, bb{o.bb.center, o.bb.radius}, depth{o.depth}
 {
 	//only allow move of root node
 	assert(o.isRoot());
@@ -85,7 +85,7 @@ Quadtree<T>::Quadtree(Quadtree<T>&& o)
 			std::make_move_iterator(o.data.end()));
 	}
 	
-	//copy child ptr
+	//copy children ptr
 	for(size_t i=0; i<4; ++i)
 	{
 		cells[i] = o.cells[i];
@@ -97,7 +97,7 @@ Quadtree<T>::Quadtree(Quadtree<T>&& o)
 template< typename T >
 Quadtree<T>::~Quadtree()
 {	
-	//delete recursively childs
+	//delete recursively children
 	if(!isLeaf())
 		for(size_t i=0; i<4; ++i)
 			delete cells[i];
@@ -106,12 +106,14 @@ Quadtree<T>::~Quadtree()
 template< typename T >	
 Quadtree<T>& Quadtree<T>::operator=(const Quadtree<T>&o)
 {
-	if (!o.parent) parent = nullptr;
+	if (!o.parent) 
+	    parent = nullptr;
+	    
 	depth=o.depth;
 	
 	if(o.isLeaf()) //Leaf case
 	{
-		//nullify childs
+		//nullify children
 		for(size_t i=0; i<4; ++i)
 			cells[i]= nullptr;
 		//Copy data
@@ -151,7 +153,7 @@ Quadtree<T>& Quadtree<T>::operator=(Quadtree<T>&&o)
 			std::make_move_iterator(o.data.end()));
 	}
 	
-	//copy childs ptrs
+	//copy children ptrs
 	for(size_t i=0; i<4; ++i)
 	{
 		cells[i] = o.cells[i];
@@ -178,7 +180,7 @@ bool Quadtree<T>::isEmpty() const
 	return (data.size() == 0);
 }
 template< typename T >
-size_t Quadtree<T>::idx(const XY& xy) const
+size_t Quadtree<T>::idx(const Point& xy) const
 {
 	size_t id = 0;
 	id|= ((xy.x > bb.center.x) << 0);
@@ -226,11 +228,11 @@ bool Quadtree<T>::build(const DP& pts, size_t maxDataByNode, bool parallel_build
 	BoundingBox box;
 	
 	Vector minValues = pts.features.rowwise().minCoeff();
-	XY min{minValues(0), minValues(1)};
+	Point min{minValues(0), minValues(1)};
 	Vector maxValues = pts.features.rowwise().maxCoeff();
-	XY max{maxValues(0), maxValues(1)};
+	Point max{maxValues(0), maxValues(1)};
 	
-	XY radii = max - min;
+	Point radii = max - min;
 	box.center = min + radii * 0.5;
 	box.radius = radii.x;
 	if (box.radius < radii.y) box.radius = radii.y;
@@ -259,12 +261,12 @@ bool Quadtree<T>::build(const DP& pts, size_t maxDataByNode, bool parallel_build
 template< typename T >
 bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb, size_t maxDataByNode)
 {
-	static XY offsetTable[4] =
+	static Point offsetTable[4] =
 		{
-			XY{-0.5, -0.5},
-			XY{+0.5, -0.5},
-			XY{-0.5, +0.5},
-			XY{+0.5, +0.5}
+			Point{-0.5, -0.5},
+			Point{+0.5, -0.5},
+			Point{-0.5, +0.5},
+			Point{+0.5, +0.5}
 		};
 	//Check maxData count
 	if(datas.size() <= maxDataByNode)
@@ -288,7 +290,7 @@ bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb,
 		
 	for(auto&& d : datas)
 	{
-		//FIXME: Should be a generic conversion from DataPoint considering Data to XY
+		//FIXME: Should be a generic conversion from DataPoint considering Data to Point
 		(sDatas[idx( TO_XY(pts,d) )]).emplace_back(d);
 	}
 	
@@ -300,7 +302,7 @@ bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb,
 	const T half_radius = this->bb.radius * 0.5;
 	for(size_t i=0; i<4; ++i)
 	{
-		const XY offset = offsetTable[i] * this->bb.radius;
+		const Point offset = offsetTable[i] * this->bb.radius;
 		boxes[i].radius = half_radius;
 		boxes[i].center = this->bb.center + offset;
 	}
@@ -310,6 +312,7 @@ bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb,
 	for(size_t i=0; i<4; ++i)
 	{
 		cells[i] = new Quadtree<T>();
+		//Assign depth
 		cells[i]->depth = this->depth+1;
 		ret = ret and cells[i]->build(pts, std::move(sDatas[i]), std::move(boxes[i]), maxDataByNode);		
 		//Assign parent
@@ -323,12 +326,12 @@ bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb,
 template< typename T >
 bool Quadtree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox && bb, size_t maxDataByNode)
 {
-	static XY offsetTable[4] =
+	static Point offsetTable[4] =
 		{
-			XY{-0.5, -0.5},
-			XY{+0.5, -0.5},
-			XY{-0.5, +0.5},
-			XY{+0.5, +0.5}
+			Point{-0.5, -0.5},
+			Point{+0.5, -0.5},
+			Point{-0.5, +0.5},
+			Point{+0.5, +0.5}
 		};
 	
 	//Check maxData count
@@ -353,7 +356,7 @@ bool Quadtree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox &&
 		
 	for(auto&& d : datas)
 	{
-		//FIXME: Should be a generic conversion from DataPoint considering Data to XY
+		//FIXME: Should be a generic conversion from DataPoint considering Data to Point
 		(sDatas[idx( TO_XY(pts,d) )]).emplace_back(d);
 	}
 	
@@ -365,7 +368,7 @@ bool Quadtree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox &&
 	const T half_radius = this->bb.radius * 0.5;
 	for(size_t i=0; i<4; ++i)
 	{
-		const XY offset = offsetTable[i] * this->bb.radius;
+		const Point offset = offsetTable[i] * this->bb.radius;
 		boxes[i].radius = half_radius;
 		boxes[i].center = this->bb.center + offset;
 	}
@@ -402,11 +405,11 @@ bool Quadtree<T>::build(const DP& pts, T maxSizeByNode, bool parallel_build)
 	BoundingBox box;
 	
 	Vector minValues = pts.features.rowwise().minCoeff();
-	XY min{minValues(0), minValues(1)};
+	Point min{minValues(0), minValues(1)};
 	Vector maxValues = pts.features.rowwise().maxCoeff();
-	XY max{maxValues(0), maxValues(1)};
+	Point max{maxValues(0), maxValues(1)};
 	
-	XY radii = max - min;
+	Point radii = max - min;
 	box.center = min + radii * 0.5;
 	box.radius = radii.x;
 	if (box.radius < radii.y) box.radius = radii.y;
@@ -435,14 +438,14 @@ bool Quadtree<T>::build(const DP& pts, T maxSizeByNode, bool parallel_build)
 template< typename T >
 bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb, T maxSizeByNode)
 {
-	static XY offsetTable[4] =
+	static Point offsetTable[4] =
 		{
-			XY{-0.5, -0.5},
-			XY{+0.5, -0.5},
-			XY{-0.5, +0.5},
-			XY{+0.5, +0.5}
+			Point{-0.5, -0.5},
+			Point{+0.5, -0.5},
+			Point{-0.5, +0.5},
+			Point{+0.5, +0.5}
 		};
-	//Check maxData count
+	//Check bounding box size or if there is data
 	if((bb.radius*2.0 <= maxSizeByNode) or (datas.size() <= 1))
 	{
 		//insert data
@@ -464,7 +467,7 @@ bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb,
 		
 	for(auto&& d : datas)
 	{
-		//FIXME: Should be a generic conversion from DataPoint considering Data to XY
+		//FIXME: Should be a generic conversion from DataPoint considering Data to Point
 		(sDatas[idx( TO_XY(pts,d) )]).emplace_back(d);
 	}
 	
@@ -476,7 +479,7 @@ bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb,
 	const T half_radius = this->bb.radius * 0.5;
 	for(size_t i=0; i<4; ++i)
 	{
-		const XY offset = offsetTable[i] * this->bb.radius;
+		const Point offset = offsetTable[i] * this->bb.radius;
 		boxes[i].radius = half_radius;
 		boxes[i].center = this->bb.center + offset;
 	}
@@ -486,6 +489,7 @@ bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb,
 	for(size_t i=0; i<4; ++i)
 	{
 		cells[i] = new Quadtree<T>();
+		//Assign depth
 		cells[i]->depth = this->depth+1;	
 		ret = ret and cells[i]->build(pts, std::move(sDatas[i]), std::move(boxes[i]), maxSizeByNode);		
 		//Assign parent
@@ -498,15 +502,15 @@ bool Quadtree<T>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb,
 template< typename T >
 bool Quadtree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox && bb, T maxSizeByNode)
 {
-	static XY offsetTable[4] =
+	static Point offsetTable[4] =
 		{
-			XY{-0.5, -0.5},
-			XY{+0.5, -0.5},
-			XY{-0.5, +0.5},
-			XY{+0.5, +0.5}
+			Point{-0.5, -0.5},
+			Point{+0.5, -0.5},
+			Point{-0.5, +0.5},
+			Point{+0.5, +0.5}
 		};
 	
-	//Check maxData count
+	//Check bounding box size or if there is data
 	if((bb.radius*2.0 <= maxSizeByNode) or (datas.size() <= 1))
 	{			
 		//insert data
@@ -528,7 +532,7 @@ bool Quadtree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox &&
 		
 	for(auto&& d : datas)
 	{
-		//FIXME: Should be a generic conversion from DataPoint considering Data to XY
+		//FIXME: Should be a generic conversion from DataPoint considering Data to Point
 		(sDatas[idx( TO_XY(pts,d) )]).emplace_back(d);
 	}
 	
@@ -540,7 +544,7 @@ bool Quadtree<T>::build_par(const DP& pts, DataContainer&& datas, BoundingBox &&
 	const T half_radius = this->bb.radius * 0.5;
 	for(size_t i=0; i<4; ++i)
 	{
-		const XY offset = offsetTable[i] * this->bb.radius;
+		const Point offset = offsetTable[i] * this->bb.radius;
 		boxes[i].radius = half_radius;
 		boxes[i].center = this->bb.center + offset;
 	}

--- a/utest/ui/DataFilters.cpp
+++ b/utest/ui/DataFilters.cpp
@@ -498,8 +498,29 @@ TEST_F(DataFilterTest, OctreeGridDataPointsFilter)
 		//Validate transformation
 		icp.readingDataPointsFilters.clear();
 		addFilter("OctreeGridDataPointsFilter", params);
-		//validate2dTransformation();
 		validate3dTransformation();
+	}
+	
+	for(const auto& meth : samplingMethods)
+	{
+		params.clear();
+		params["buildMethod"] = "0";
+		params["maxPointByNode"] = "10";
+		params["samplingMethod"] = toParam(meth);
+		params["buildParallel"] = "1";
+		
+		octreeFilter = 
+				PM::get().DataPointsFilterRegistrar.create("OctreeGridDataPointsFilter", params);
+	
+		const DP filteredCloud = octreeFilter->filter(cloud);
+		
+		//Check number of points
+		EXPECT_GT(cloud.getNbPoints(), filteredCloud.getNbPoints());
+	
+		//Validate transformation
+		icp.readingDataPointsFilters.clear();
+		addFilter("OctreeGridDataPointsFilter", params);
+		validate2dTransformation();
 	}
 
 //CASE (3): octants max size 10cm
@@ -523,8 +544,30 @@ TEST_F(DataFilterTest, OctreeGridDataPointsFilter)
 		//Validate transformation
 		icp.readingDataPointsFilters.clear();
 		addFilter("OctreeGridDataPointsFilter", params);
-		//validate2dTransformation();
 		validate3dTransformation();
+	}
+	
+	for(const auto& meth : samplingMethods)
+	{
+		params.clear();
+		params["buildMethod"] = "1";
+		params["maxPointByNode"] = "1";
+		params["maxSizeByNode"] = "0.05";
+		params["samplingMethod"] = toParam(meth);
+		params["buildParallel"] = "1";
+	
+		octreeFilter = 
+				PM::get().DataPointsFilterRegistrar.create("OctreeGridDataPointsFilter", params);
+	
+		const DP filteredCloud = octreeFilter->filter(cloud);
+		
+		//Check number of points
+		EXPECT_GT(cloud.getNbPoints(), filteredCloud.getNbPoints());
+		
+		//Validate transformation
+		icp.readingDataPointsFilters.clear();
+		addFilter("OctreeGridDataPointsFilter", params);
+		validate2dTransformation();
 	}
 }
 


### PR DESCRIPTION
(fixes #251)

I added a [Quadtree](https://en.wikipedia.org/wiki/Quadtree) for the 2D data based on the code of the octree (see #250 for more details).

-----
Plus, I updated the`OctreeGridDataPointFilter` so it can handle 3D as well as 2D point cloud. To do so, I had to allow the `Sampler` to be applied on the Octree as well as the Quadtree by templating the `operator()`. However, it's transparent to the user.

-----
I updated the `utest` that now also test 2D transformation.

-----
The choice to develop an Quadtree separately of the Octree can be justify by the following:
- It's the responsibility of the user to choose the correct data structure adapted to his needs
- Templatize the Octree could be done, but imply that we have to specialize some processes for a 3D data or a 2D data (ex: the index calculation, the offset table, etc.)
- Having a different class for each representation let more possibility to optimize each one

The contrary can be justified too: better maintainability, no code duplication, etc. 

-----
I also correct to typo/indentation as reviewed in #250, renamed the struct `XYZ` into `Point` in the Octree and the Quadtree to be homogeneous and made the interfaces of `Point` and `BoundingBox` public. 

----
As for my previous PR, I am open to any suggestion to improve the Octree and the Quadtree.