### PR TITLE
Major revision of the Octree class

### DIFF
--- a/pointmatcher/DataPoints.cpp
+++ b/pointmatcher/DataPoints.cpp
@@ -400,6 +400,16 @@ void PointMatcher<T>::DataPoints::setColFrom(Index thisCol, const DataPoints& th
 		times.col(thisCol) = that.times.col(thatCol);
 
 }
+//! Swap column i and j in the point cloud, swap also features and descriptors if any. Assumes sizes are similar
+template<typename T>
+void PointMatcher<T>::DataPoints::swapCols(Index iCol,Index jCol)
+{
+	features.col(iCol).swap(features.col(jCol));
+	if (descriptors.cols() > 0)
+		descriptors.col(iCol).swap(descriptors.col(jCol));
+	if (times.cols() > 0)
+		times.col(iCol).swap(times.col(jCol));
+}
 
 //------------------------------------
 // Methods related to features

--- a/pointmatcher/DataPointsFilters/Elipsoids.cpp
+++ b/pointmatcher/DataPointsFilters/Elipsoids.cpp
@@ -238,7 +238,7 @@ void ElipsoidsDataPointsFilter<T>::buildNew(
 	BuildData& data, const int first, const int last, 
 	Vector&& minValues, Vector&& maxValues) const
 {
-  using namespace utils;
+  using namespace PointMatcherSupport;
   
   const int count(last - first);
   if (count <= int(knn))
@@ -285,7 +285,7 @@ template<typename T>
 void ElipsoidsDataPointsFilter<T>::fuseRange(
 	BuildData& data, const int first, const int last) const
 {
-  using namespace utils;
+  using namespace PointMatcherSupport;
   
   typedef typename Eigen::Matrix<boost::int64_t, Eigen::Dynamic, Eigen::Dynamic> Int64Matrix;
 

--- a/pointmatcher/DataPointsFilters/Gestalt.cpp
+++ b/pointmatcher/DataPointsFilters/Gestalt.cpp
@@ -343,7 +343,7 @@ template<typename T>
 void GestaltDataPointsFilter<T>::fuseRange(
 	BuildData& data, DataPoints& input, const int first, const int last) const
 {
-  using namespace utils;
+  using namespace PointMatcherSupport;
   
   typedef typename Eigen::Matrix<boost::int64_t, Eigen::Dynamic, Eigen::Dynamic> Int64Matrix;
 

--- a/pointmatcher/DataPointsFilters/OctreeGrid.cpp
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.cpp
@@ -57,7 +57,8 @@ OctreeGridDataPointsFilter<T>::FirstPtsSampler::FirstPtsSampler(DataPoints& dp)
 }
 
 template <typename T>
-bool OctreeGridDataPointsFilter<T>::FirstPtsSampler::operator()(Octree<T>& oc)
+template<std::size_t dim>
+bool OctreeGridDataPointsFilter<T>::FirstPtsSampler::operator()(Octree_<T,dim>& oc)
 {
 	if(oc.isLeaf() and not oc.isEmpty())
 	{			
@@ -107,7 +108,8 @@ OctreeGridDataPointsFilter<T>::RandomPtsSampler::RandomPtsSampler(
 	std::srand(seed);
 }
 template<typename T>
-bool OctreeGridDataPointsFilter<T>::RandomPtsSampler::operator()(Octree<T>& oc)
+template<std::size_t dim>
+bool OctreeGridDataPointsFilter<T>::RandomPtsSampler::operator()(Octree_<T,dim>& oc)
 {
 	if(oc.isLeaf() and not oc.isEmpty())
 	{			
@@ -154,7 +156,8 @@ OctreeGridDataPointsFilter<T>::CentroidSampler::CentroidSampler(DataPoints& dp)
 }
 	
 template<typename T>
-bool OctreeGridDataPointsFilter<T>::CentroidSampler::operator()(Octree<T>& oc)
+template<std::size_t dim>
+bool OctreeGridDataPointsFilter<T>::CentroidSampler::operator()(Octree_<T,dim>& oc)
 {
 	if(oc.isLeaf() and not oc.isEmpty())
 	{			
@@ -253,9 +256,23 @@ OctreeGridDataPointsFilter<T>::filter(const DataPoints& input)
 template <typename T>
 void OctreeGridDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 {
-	assert(cloud.features.rows() == 4); //3D points only
+	const std::size_t featDim = cloud.features.rows();
 	
-	Octree<T> oc{};
+	assert(featDim == 4 or featDim == 3);
+
+	if(featDim==3) //2D case
+		this->sample<2>(cloud);
+		
+	else if(featDim==4) //3D case
+		this->sample<3>(cloud);
+}
+
+template<typename T>
+template<std::size_t dim>
+void OctreeGridDataPointsFilter<T>::sample(DataPoints& cloud)
+{
+	Octree_<T,dim> oc;
+	
 	oc.build(cloud, maxPointByNode, maxSizeByNode, buildParallel);
 	
 	switch(samplingMethod)
@@ -283,6 +300,7 @@ void OctreeGridDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 		}
 	}
 }
+
 
 template struct OctreeGridDataPointsFilter<float>;
 template struct OctreeGridDataPointsFilter<double>;

--- a/pointmatcher/DataPointsFilters/OctreeGrid.cpp
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.cpp
@@ -176,7 +176,7 @@ bool OctreeGridDataPointsFilter<T>::CentroidSampler::operator()(Octree_<T,dim>& 
 			j = mapidx[d];
 		
 		//We sum all the data in the first data
-		for(std::size_t id=0;id<nbData;++id)
+		for(std::size_t id=1;id<nbData;++id)
 		{
 			//get current idx
 			const auto& curId = (*data)[id];

--- a/pointmatcher/DataPointsFilters/OctreeGrid.cpp
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.cpp
@@ -175,8 +175,6 @@ bool OctreeGridDataPointsFilter<T>::CentroidSampler::operator()(Octree_<T,dim>& 
 		if(std::size_t(d)<idx)
 			j = mapidx[d];
 		
-		T acc[featDim-1] = {0.};
-		
 		//We sum all the data in the first data
 		for(std::size_t id=0;id<nbData;++id)
 		{
@@ -189,7 +187,7 @@ bool OctreeGridDataPointsFilter<T>::CentroidSampler::operator()(Octree_<T,dim>& 
 				i = mapidx[curId];
 			
 			for (int f = 0; f < (featDim - 1); ++f)
-				acc[f] += pts.features(f,i);
+				pts.features(f,j) += pts.features(f,i);
 			
 			if (pts.descriptors.cols() > 0)
 				for (int d = 0; d < descDim; ++d)
@@ -202,7 +200,7 @@ bool OctreeGridDataPointsFilter<T>::CentroidSampler::operator()(Octree_<T,dim>& 
 		
 		// Normalize sums to get centroid (average)
 		for (int f = 0; f < (featDim - 1); ++f)
-			pts.features(f,j) = acc[f]/T(nbData);
+			pts.features(f,j) /= T(nbData);
 		
 		if (pts.descriptors.cols() > 0)
 			for (int d = 0; d < descDim; ++d)

--- a/pointmatcher/DataPointsFilters/OctreeGrid.cpp
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.cpp
@@ -34,21 +34,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include "OctreeGrid.h"
 
-//Helper function
-//FIXME: to put in DataPoints implementation
-template<typename T>
-void swapCols(typename PointMatcher<T>::DataPoints& self, 
-	typename PointMatcher<T>::DataPoints::Index iCol, 
-	typename PointMatcher<T>::DataPoints::Index jCol)
-{
-	//Switch columns j and i
-	self.features.col(iCol).swap(self.features.col(jCol));
-	if (self.descriptors.cols() > 0)
-		self.descriptors.col(iCol).swap(self.descriptors.col(jCol));
-	if (self.times.cols() > 0)
-		self.times.col(iCol).swap(self.times.col(jCol));
-}
-
 //Define Visitor classes to apply processing
 template<typename T>
 OctreeGridDataPointsFilter<T>::FirstPtsSampler::FirstPtsSampler(DataPoints& dp) 
@@ -72,7 +57,7 @@ bool OctreeGridDataPointsFilter<T>::FirstPtsSampler::operator()(Octree_<T,dim>& 
 			j = mapidx[d];
 			
 		//Switch columns j and idx
-		swapCols<T>(pts, idx, j);
+		pts.swapCols(idx, j);
 				
 		//Maintain new index position	
 		mapidx[idx] = j;
@@ -128,7 +113,7 @@ bool OctreeGridDataPointsFilter<T>::RandomPtsSampler::operator()(Octree_<T,dim>&
 			j = mapidx[d];
 			
 		//Switch columns j and idx
-		swapCols<T>(pts, idx, j);	
+		pts.swapCols(idx, j);	
 		
 		//Maintain new index position	
 		mapidx[idx] = j;
@@ -211,7 +196,7 @@ bool OctreeGridDataPointsFilter<T>::CentroidSampler::operator()(Octree_<T,dim>& 
 				pts.times(t,j) /= T(nbData);	
 								
 		//Switch columns j and idx
-		swapCols<T>(pts, idx, j);
+		pts.swapCols(idx, j);
 		
 		//Maintain new index position	
 		mapidx[idx] = j;

--- a/pointmatcher/DataPointsFilters/OctreeGrid.h
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.h
@@ -98,7 +98,10 @@ public:
 
 		FirstPtsSampler(DataPoints& dp);
 		virtual ~FirstPtsSampler(){}
-		virtual bool operator()(Octree<T>& oc);
+		
+		template<std::size_t dim>
+		bool operator()(Octree_<T,dim>& oc);
+		
 		virtual bool finalize();
 	};
 	struct RandomPtsSampler : public FirstPtsSampler
@@ -113,7 +116,9 @@ public:
 		RandomPtsSampler(DataPoints& dp, const std::size_t seed_);
 		virtual ~RandomPtsSampler(){}
 	
-		virtual bool operator()(Octree<T>& oc);
+		template<std::size_t dim>
+		bool operator()(Octree_<T,dim>& oc);
+		
 		virtual bool finalize();
 	};
 	struct CentroidSampler : public FirstPtsSampler
@@ -126,7 +131,8 @@ public:
 	
 		virtual ~CentroidSampler(){}
 	
-		virtual bool operator()(Octree<T>& oc);
+		template<std::size_t dim>
+		bool operator()(Octree_<T,dim>& oc);
 	};
 
 //-------	
@@ -150,6 +156,9 @@ public:
 
 	virtual DataPoints filter(const DataPoints& input);
 	virtual void inPlaceFilter(DataPoints& cloud);
+
+private:
+	template<std::size_t dim> void sample(DataPoints& cloud);
 };
 
 //Helper function

--- a/pointmatcher/DataPointsFilters/OctreeGrid.h
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.h
@@ -160,11 +160,3 @@ public:
 private:
 	template<std::size_t dim> void sample(DataPoints& cloud);
 };
-
-//Helper function
-template<typename T>
-void swapCols(typename PointMatcher<T>::DataPoints& self, 
-	typename PointMatcher<T>::DataPoints::Index iCol, 
-	typename PointMatcher<T>::DataPoints::Index jCol);
-	
-

--- a/pointmatcher/DataPointsFilters/OctreeGrid.h
+++ b/pointmatcher/DataPointsFilters/OctreeGrid.h
@@ -77,10 +77,9 @@ struct OctreeGridDataPointsFilter : public PointMatcher<T>::DataPointsFilter
 	inline static const ParametersDoc availableParameters()
 	{
 		return boost::assign::list_of<ParameterDoc>
-		( "buildMethod", "Method to build the Octree: maxPoint (0), maxSize (1)", "0", "0", "1", &P::Comp<int> )
 		( "buildParallel", "If 1 (true), use threads to build the octree.", "1", "0", "1", P::Comp<bool> )
 		( "maxPointByNode", "Number of point under which the octree stop dividing.", "1", "1", "4294967295", &P::Comp<std::size_t> )
-		( "maxSizeByNode", "Size of the bounding box under which the octree stop dividing.", "0.01", "0.0001", "+inf", &P::Comp<T> )
+		( "maxSizeByNode", "Size of the bounding box under which the octree stop dividing.", "0", "0", "+inf", &P::Comp<T> )
 		( "samplingMethod", "Method to sample the Octree: First Point (0), Random (1), Centroid (2) (more accurate but costly)", "0", "0", "2", &P::Comp<int> )
 		//FIXME: add seed parameter for the random sampling
 		;
@@ -131,12 +130,10 @@ public:
 	};
 
 //-------	
-	enum BuildMethod : int { MAX_POINT=0, MAX_SIZE=1 }; 
 	enum SamplingMethod : int { FIRST_PTS=0, RAND_PTS=1, CENTROID=2 };
 
 //Atributes
-	bool parallel_build;
-	BuildMethod buildMethod;
+	bool buildParallel;
 	
 	std::size_t maxPointByNode;
 	T           maxSizeByNode;

--- a/pointmatcher/DataPointsFilters/SamplingSurfaceNormal.cpp
+++ b/pointmatcher/DataPointsFilters/SamplingSurfaceNormal.cpp
@@ -174,7 +174,7 @@ void SamplingSurfaceNormalDataPointsFilter<T>::buildNew(
 	BuildData& data, const int first, const int last, 
 	Vector&& minValues, Vector&& maxValues) const
 {
-	using namespace utils;
+	using namespace PointMatcherSupport;
 	
 	const int count(last - first);
 	if (count <= int(knn))
@@ -225,7 +225,7 @@ template<typename T>
 void SamplingSurfaceNormalDataPointsFilter<T>::fuseRange(
 	BuildData& data, const int first, const int last) const
 {
-	using namespace utils;
+	using namespace PointMatcherSupport;
 	
 	const int colCount(last-first);
 	const int featDim(data.features.rows());

--- a/pointmatcher/DataPointsFilters/SurfaceNormal.cpp
+++ b/pointmatcher/DataPointsFilters/SurfaceNormal.cpp
@@ -88,7 +88,7 @@ void SurfaceNormalDataPointsFilter<T>::inPlaceFilter(
 	typedef typename MatchersImpl<T>::KDTreeMatcher KDTreeMatcher;
 	typedef typename PointMatcher<T>::Matches Matches;
 	
-	using namespace utils;
+	using namespace PointMatcherSupport;
 
 	const int pointsCount(cloud.features.cols());
 	const int featDim(cloud.features.rows());

--- a/pointmatcher/DataPointsFilters/utils/octree.h
+++ b/pointmatcher/DataPointsFilters/utils/octree.h
@@ -102,14 +102,14 @@ private:
 	
 	/******************************************************
 	 *	Cells id are assigned as their position 
-	 *   on a hamming cube (+ greater than center, - lower than center)
+	 *   from the center (+ greater than center, - lower than center)
 	 *
 	 *		for 3D case									for 2D case
 	 *
 	 *	  	0	1	2	3	4	5	6	7		  	0	1	2	3
 	 * 	x:	-	+	-	+	-	+	-	+		x:	-	+	-	+
-	 * 	z:	-	-	+	+	-	-	+	+		y:	-	-	+	+	
-	 * 	y:	-	-	-	-	+	+	+	+
+	 * 	y:	-	-	+	+	-	-	+	+		y:	-	-	+	+	
+	 * 	z:	-	-	-	-	+	+	+	+
 	 *
 	 *****************************************************/
 	
@@ -122,11 +122,11 @@ private:
 public:
 	Octree_();
 	Octree_(const Octree_<T,dim>& o); //Deep-copy
-	Octree_(Octree_<T,dim>&&o);
+	Octree_(Octree_<T,dim>&& o);
 	
 	virtual ~Octree_();
 	
-	Octree_<T,dim>& operator=(const Octree_<T,dim>&o);//Deep-copy
+	Octree_<T,dim>& operator=(const Octree_<T,dim>& o);//Deep-copy
 	Octree_<T,dim>& operator=(Octree_<T,dim>&& o);
 	
 	bool isLeaf() const;
@@ -145,7 +145,7 @@ public:
 
 protected:
 	//real build function
-	bool build(const DP& pts, DataContainer&& datas, BoundingBox && bb, size_t maxDataByNode=1, T maxSizeByNode=T(0.), bool parallelBuild=false);
+	bool build(const DP& pts, DataContainer&& datas, BoundingBox&& bb, size_t maxDataByNode=1, T maxSizeByNode=T(0.), bool parallelBuild=false);
 	
 	inline DataContainer toData(const DP& pts, const std::vector<Id>& ids);
 	

--- a/pointmatcher/DataPointsFilters/utils/octree.h
+++ b/pointmatcher/DataPointsFilters/utils/octree.h
@@ -137,6 +137,10 @@ public:
 	inline std::size_t idx(const DP& pts, const Data d) const;
 	
 	std::size_t getDepth() const;
+	
+	T getRadius() const;
+	Point getCenter() const;
+	
 	DataContainer * getData();
 	Octree_<T, dim>* operator[](std::size_t idx);
 	

--- a/pointmatcher/DataPointsFilters/utils/octree.h
+++ b/pointmatcher/DataPointsFilters/utils/octree.h
@@ -77,7 +77,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 template < typename T, std::size_t dim >
 class Octree_ 
 {
-public:	
+public:		
 	using PM = PointMatcher<T>;
 	using DP = typename PM::DataPoints; /**/
 	using Id = typename DP::Index; /**/
@@ -88,7 +88,7 @@ public:
 	using Point = Eigen::Matrix<T,dim,1>;
 	
 //private:
-	static constexpr std::size_t nbCells = utils::pow_<std::size_t, 2, dim>::value;
+	static constexpr std::size_t nbCells = PointMatcherSupport::pow<std::size_t, 2, dim>::value;
 	
 private:
 	struct BoundingBox 

--- a/pointmatcher/DataPointsFilters/utils/octree.h
+++ b/pointmatcher/DataPointsFilters/utils/octree.h
@@ -88,7 +88,7 @@ public:
 	using Point = Eigen::Matrix<T,dim,1>;
 	
 //private:
-	static constexpr std::size_t nbCells = PointMatcherSupport::pow<std::size_t, 2, dim>::value;
+	static constexpr std::size_t nbCells = PointMatcherSupport::pow(2, dim);
 	
 private:
 	struct BoundingBox 

--- a/pointmatcher/DataPointsFilters/utils/octree.hpp
+++ b/pointmatcher/DataPointsFilters/utils/octree.hpp
@@ -298,10 +298,10 @@ struct helper<T,2>
 template<typename T>
 const typename Octree_<T,2>::Point helper<T,2>::offsetTable[Octree_<T,2>::nbCells] = 
 		{
-			typename Octree_<T,2>::PointPoint{-0.5, -0.5},
-			typename Octree_<T,2>::PointPoint{+0.5, -0.5},
-			typename Octree_<T,2>::PointPoint{-0.5, +0.5},
-			typename Octree_<T,2>::PointPoint{+0.5, +0.5}
+			typename Octree_<T,2>::Point{-0.5, -0.5},
+			typename Octree_<T,2>::Point{+0.5, -0.5},
+			typename Octree_<T,2>::Point{-0.5, +0.5},
+			typename Octree_<T,2>::Point{+0.5, +0.5}
 		};
 
 

--- a/pointmatcher/DataPointsFilters/utils/octree.hpp
+++ b/pointmatcher/DataPointsFilters/utils/octree.hpp
@@ -257,44 +257,40 @@ bool Octree_<T,dim>::build(const DP& pts, size_t maxDataByNode, T maxSizeByNode,
 
 //Offset lookup table
 template<typename T, std::size_t dim>
-struct helper
-{
-	static const typename Octree_<T,dim>::Point offsetTable[Octree_<T,dim>::nbCells];
-};
-template<typename T, std::size_t dim>
-const typename Octree_<T,dim>::Point helper<T,dim>::offsetTable[Octree_<T,dim>::nbCells] = {typename Octree_<T,dim>::Point{}};
+struct OctreeHelper;
 
 template<typename T>
-struct helper<T,3>
+struct OctreeHelper<T,3>
 {
 	static const typename Octree_<T,3>::Point offsetTable[Octree_<T,3>::nbCells];
 };
 template<typename T>
-const typename Octree_<T,3>::Point helper<T,3>::offsetTable[Octree_<T,3>::nbCells] = 
+const typename Octree_<T,3>::Point OctreeHelper<T,3>::offsetTable[Octree_<T,3>::nbCells] = 
 		{
-			typename Octree_<T,3>::Point{-0.5, -0.5, -0.5},
-			typename Octree_<T,3>::Point{+0.5, -0.5, -0.5},
-			typename Octree_<T,3>::Point{-0.5, -0.5, +0.5},
-			typename Octree_<T,3>::Point{+0.5, -0.5, +0.5},
-			typename Octree_<T,3>::Point{-0.5, +0.5, -0.5},
-			typename Octree_<T,3>::Point{+0.5, +0.5, -0.5},
-			typename Octree_<T,3>::Point{-0.5, +0.5, +0.5},
-			typename Octree_<T,3>::Point{+0.5, +0.5, +0.5}
+			{-0.5, -0.5, -0.5},
+			{+0.5, -0.5, -0.5},
+			{-0.5, +0.5, -0.5},
+			{+0.5, +0.5, -0.5},
+			{-0.5, -0.5, +0.5},
+			{+0.5, -0.5, +0.5},
+			{-0.5, +0.5, +0.5},
+			{+0.5, +0.5, +0.5}
 		};
 
 template<typename T>
-struct helper<T,2>
+struct OctreeHelper<T,2>
 {
 	static const typename Octree_<T,2>::Point offsetTable[Octree_<T,2>::nbCells];
 };
 template<typename T>
-const typename Octree_<T,2>::Point helper<T,2>::offsetTable[Octree_<T,2>::nbCells] = 
+const typename Octree_<T,2>::Point OctreeHelper<T,2>::offsetTable[Octree_<T,2>::nbCells] = 
 		{
-			typename Octree_<T,2>::Point{-0.5, -0.5},
-			typename Octree_<T,2>::Point{+0.5, -0.5},
-			typename Octree_<T,2>::Point{-0.5, +0.5},
-			typename Octree_<T,2>::Point{+0.5, +0.5}
+			{-0.5, -0.5},
+			{+0.5, -0.5},
+			{-0.5, +0.5},
+			{+0.5, +0.5}
 		};
+
 
 
 template<typename T, std::size_t dim>
@@ -332,7 +328,7 @@ bool Octree_<T,dim>::build(const DP& pts, DataContainer&& datas, BoundingBox && 
 	const T half_radius = this->bb.radius * 0.5;
 	for(size_t i=0; i<nbCells; ++i)
 	{
-		const Point offset = helper<T,dim>::offsetTable[i] * this->bb.radius;
+		const Point offset = OctreeHelper<T,dim>::offsetTable[i] * this->bb.radius;
 		boxes[i].radius = half_radius;
 		boxes[i].center = this->bb.center + offset;
 	}

--- a/pointmatcher/DataPointsFilters/utils/octree.hpp
+++ b/pointmatcher/DataPointsFilters/utils/octree.hpp
@@ -198,6 +198,16 @@ size_t Octree_<T,dim>::getDepth() const
 	return depth;
 }
 template<typename T, std::size_t dim>
+T Octree_<T,dim>::getRadius() const
+{
+	return bb.radius;
+}
+template<typename T, std::size_t dim>
+typename Octree_<T,dim>::Point Octree_<T,dim>::getCenter() const
+{
+	return bb.center;
+}
+template<typename T, std::size_t dim>
 typename Octree_<T,dim>::DataContainer * Octree_<T,dim>::getData()
 {
 	return &data;

--- a/pointmatcher/DataPointsFilters/utils/octree.hpp
+++ b/pointmatcher/DataPointsFilters/utils/octree.hpp
@@ -180,14 +180,6 @@ template<typename T, std::size_t dim>
 size_t Octree_<T,dim>::idx(const Point& pt) const
 {
 	size_t id = 0;
-	if(dim==3) //Special case for the hamming cube
-	{
-		id|= ((pt(0) > bb.center(0)) << 0);
-		id|= ((pt(2) > bb.center(2)) << 1);
-		id|= ((pt(1) > bb.center(1)) << 2);
-		
-		return id;
-	}
 
 	for(size_t i=0; i<dim; ++i)
 		id|= ((pt(i) > bb.center(i)) << i);

--- a/pointmatcher/DataPointsFilters/utils/octree.hpp
+++ b/pointmatcher/DataPointsFilters/utils/octree.hpp
@@ -260,9 +260,7 @@ bool Octree_<T,dim>::build(const DP& pts, size_t maxDataByNode, T maxSizeByNode,
 	DataContainer datas = toData(pts, indexes);
 	
 	//build
-	bool ret = this->build(pts, std::move(datas), std::move(box), maxDataByNode, maxSizeByNode, parallelBuild);
-
-	return ret;
+	return this->build(pts, std::move(datas), std::move(box), maxDataByNode, maxSizeByNode, parallelBuild);
 }
 
 //Offset lookup table
@@ -300,8 +298,6 @@ const typename Octree_<T,2>::Point OctreeHelper<T,2>::offsetTable[Octree_<T,2>::
 			{-0.5, +0.5},
 			{+0.5, +0.5}
 		};
-
-
 
 template<typename T, std::size_t dim>
 bool Octree_<T,dim>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb, 
@@ -359,10 +355,10 @@ bool Octree_<T,dim>::build(const DP& pts, DataContainer&& datas, BoundingBox && 
 				this->cells[i]->build(pts, std::move(sDatas[i]), std::move(boxes[i]), maxDataByNode, maxSizeByNode, false);	
 			};
 		
-		if(not parallelBuild)
-			compute();
-		else
+		if(parallelBuild)
 			futures.push_back( std::async( std::launch::async, compute ));
+		else
+			compute();
 	}
 
 	for(auto& f : futures) f.get();

--- a/pointmatcher/DataPointsFilters/utils/octree.hpp
+++ b/pointmatcher/DataPointsFilters/utils/octree.hpp
@@ -307,6 +307,10 @@ template<typename T, std::size_t dim>
 bool Octree_<T,dim>::build(const DP& pts, DataContainer&& datas, BoundingBox && bb, 
 	size_t maxDataByNode, T maxSizeByNode, bool parallelBuild)
 {
+	//Assign bounding box
+	this->bb.center = bb.center;
+	this->bb.radius = bb.radius;
+
 	//Check stop condition
 	if((bb.radius*2.0 <= maxSizeByNode) or (datas.size() <= maxDataByNode))
 	{		
@@ -315,10 +319,6 @@ bool Octree_<T,dim>::build(const DP& pts, DataContainer&& datas, BoundingBox && 
 			std::make_move_iterator(datas.begin()), make_move_iterator(datas.end()));
 		return (isLeaf());
 	}
-	
-	//Assign bounding box
-	this->bb.center = bb.center;
-	this->bb.radius = bb.radius;
 	
 	//Split datas
 	const std::size_t nbData = datas.size();

--- a/pointmatcher/DataPointsFilters/utils/utils.h
+++ b/pointmatcher/DataPointsFilters/utils/utils.h
@@ -43,14 +43,10 @@ namespace PointMatcherSupport
 {
 
 template<class T>
-inline constexpr T pow_(const T base, const std::size_t exponent)
+inline constexpr T pow(const T base, const std::size_t exponent)
 {
-    return (exponent == 0 ? 1 : base * pow_(base, exponent - 1));
+    return exponent == 0 ? 1 : base * pow(base, exponent - 1);
 }
-/* use template to force compile time evaluation : https://stackoverflow.com/a/16443849 */
-template < typename T, T base, std::size_t exponent >
-using pow = std::integral_constant<T, pow_(base, exponent)>;
-
 
 template<typename T>
 struct IdxCompare

--- a/pointmatcher/DataPointsFilters/utils/utils.h
+++ b/pointmatcher/DataPointsFilters/utils/utils.h
@@ -41,6 +41,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace utils {
 
+template<class T>
+inline constexpr T pow(const T base, const std::size_t exponent)
+{
+    // (parentheses not required in next line)
+    return (exponent == 0)     ? 1 :
+           (exponent % 2 == 0) ? pow(base, exponent/2)*pow(base, exponent/2) :
+           base * pow(base, (exponent-1)/2) * pow(base, (exponent-1)/2);
+}
+template < typename T, T base, std::size_t exponent >
+using pow_ = std::integral_constant<T, pow(base, exponent)>;
+
+
 template<typename T>
 struct IdxCompare
 {

--- a/pointmatcher/DataPointsFilters/utils/utils.h
+++ b/pointmatcher/DataPointsFilters/utils/utils.h
@@ -39,18 +39,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <algorithm>
 
-namespace utils {
+namespace PointMatcherSupport
+{
 
 template<class T>
-inline constexpr T pow(const T base, const std::size_t exponent)
+inline constexpr T pow_(const T base, const std::size_t exponent)
 {
-    // (parentheses not required in next line)
-    return (exponent == 0)     ? 1 :
-           (exponent % 2 == 0) ? pow(base, exponent/2)*pow(base, exponent/2) :
-           base * pow(base, (exponent-1)/2) * pow(base, (exponent-1)/2);
+    return (exponent == 0 ? 1 : base * pow_(base, exponent - 1));
 }
 template < typename T, T base, std::size_t exponent >
-using pow_ = std::integral_constant<T, pow(base, exponent)>;
+using pow = std::integral_constant<T, pow_(base, exponent)>;
 
 
 template<typename T>
@@ -61,7 +59,7 @@ struct IdxCompare
 
 	IdxCompare(const typename PointMatcher<T>::Vector& target): target(target) {}
 
-	bool operator()(size_t a, size_t b) const { return target(a,0) < target(b,0); }
+	bool operator()(size_t a, size_t b) const { return target(a, 0) < target(b, 0); }
 };
 
 

--- a/pointmatcher/DataPointsFilters/utils/utils.h
+++ b/pointmatcher/DataPointsFilters/utils/utils.h
@@ -47,6 +47,7 @@ inline constexpr T pow_(const T base, const std::size_t exponent)
 {
     return (exponent == 0 ? 1 : base * pow_(base, exponent - 1));
 }
+/* use template to force compile time evaluation : https://stackoverflow.com/a/16443849 */
 template < typename T, T base, std::size_t exponent >
 using pow = std::integral_constant<T, pow_(base, exponent)>;
 

--- a/pointmatcher/PointMatcher.h
+++ b/pointmatcher/PointMatcher.h
@@ -278,6 +278,7 @@ struct PointMatcher
 		DataPoints createSimilarEmpty() const;
 		DataPoints createSimilarEmpty(Index pointCount) const;
 		void setColFrom(Index thisCol, const DataPoints& that, Index thatCol);
+		void swapCols(Index iCol,Index jCol);
 		
 		// methods related to features
 		void allocateFeature(const std::string& name, const unsigned dim);

--- a/utest/ui/DataFilters.cpp
+++ b/utest/ui/DataFilters.cpp
@@ -458,8 +458,7 @@ TEST_F(DataFilterTest, OctreeGridDataPointsFilter)
 				params["samplingMethod"] = toParam(meth);
 				params["buildParallel"] = "1";
 	
-				octreeFilter = 
-						PM::get().DataPointsFilterRegistrar.create("OctreeGridDataPointsFilter", params);
+				octreeFilter = PM::get().DataPointsFilterRegistrar.create("OctreeGridDataPointsFilter", params);
 
 				const DP filteredCloud = octreeFilter->filter(cloud);
 			

--- a/utest/ui/DataFilters.cpp
+++ b/utest/ui/DataFilters.cpp
@@ -449,7 +449,7 @@ TEST_F(DataFilterTest, OctreeGridDataPointsFilter)
 	PM::DataPointsFilter* octreeFilter;
 	
 	for(const int meth : {0,1,2})
-		for(const size_t maxData : {1,200})
+		for(const size_t maxData : {1,20})
 			for(const float maxSize : {0.,0.1})
 			{
 				params.clear();
@@ -483,7 +483,7 @@ TEST_F(DataFilterTest, OctreeGridDataPointsFilter)
 				//Validate transformation
 				icp.readingDataPointsFilters.clear();
 				addFilter("OctreeGridDataPointsFilter", params);
-				//validate2dTransformation();
+				validate2dTransformation();
 				validate3dTransformation();
 			}
 }

--- a/utest/ui/DataFilters.cpp
+++ b/utest/ui/DataFilters.cpp
@@ -449,8 +449,8 @@ TEST_F(DataFilterTest, OctreeGridDataPointsFilter)
 	PM::DataPointsFilter* octreeFilter;
 	
 	for(const int meth : {0,1,2})
-		for(const size_t maxData : {1,20})
-			for(const float maxSize : {0.,0.1})
+		for(const size_t maxData : {1,5})
+			for(const float maxSize : {0.,0.05})
 			{
 				params.clear();
 				params["maxPointByNode"] = toParam(maxData);


### PR DESCRIPTION
I took into account the reviews from the previous PR about the octree #250 :
- The octree is now templated on the dimension (`dim=3` for the [Octree](https://en.wikipedia.org/wiki/Octree) (3D) case; `dim=2` for the [Quadtree](https://en.wikipedia.org/wiki/Quadtree) (2D) case)
- No more code duplication. Only one `build` function that handle parallel build and with merged stop criterion
- The struct `XYZ` has been replace by `Eigen::Matrix<T,dim,1>` to avoid duplication
- The use of macro has been replaced by functions (ex: `toData`, overload of `idx`)
- `std::thread` has been replaced by `std::async` with `std::launch::async` policy

The new implementation natively support the 2D case with the Quadtree (i.e. a `Quadtree` is an `Octree_<T,2>`).   (fixes #251) 

I created the following aliases not to break the existing API:
```c++
template<typename T> using Quadtree = Octree_<T,2>;
template<typename T> using Octree = Octree_<T,3>;
```

----
The unit test has been rewrite too, in a more compact way and with 2D test case for the Quadtree.

---
I hope this version is cleaner than the previous one. Still open to suggestion, ~in particularly for the choice of the 3D indexes on an Hamming cube (as discussed in #250)~.

**Edit:** the indexes on the Hamming cube had been removed to have a more natural order.
