### PR TITLE
Add new filter based on Normal Space sampling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,8 @@ set(POINTMATCHER_SRC
 	pointmatcher/DataPointsFilters/CutAtDescriptorThreshold.cpp
 	pointmatcher/DataPointsFilters/Elipsoids.cpp
 	pointmatcher/DataPointsFilters/Gestalt.cpp
-	pointmatcher/DataPointsFilters/OctreeGrid.cpp		
+	pointmatcher/DataPointsFilters/OctreeGrid.cpp
+	pointmatcher/DataPointsFilters/NormalSpace.cpp	
 )
 
 include_directories(${CMAKE_SOURCE_DIR})

--- a/pointmatcher/DataPointsFilters/NormalSpace.cpp
+++ b/pointmatcher/DataPointsFilters/NormalSpace.cpp
@@ -91,7 +91,7 @@ void NormalSpaceDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 		//Theta = polar angle in [0 ; pi]
 		const T theta = std::acos(normals(2, i)); 
 		//Phi = azimuthal angle in [0 ; 2pi] 
-		const T phi = std::atan2(normals(1, i), normals(0, i)) + M_PI;
+		const T phi = std::fmod(std::atan2(normals(1, i), normals(0, i)) + 2. * M_PI, 2. * M_PI);
 		
 		//assert(theta >= 0. and theta =< M_PI and phi >= 0. and phi <= 2.*M_PI);
 		

--- a/pointmatcher/DataPointsFilters/NormalSpace.cpp
+++ b/pointmatcher/DataPointsFilters/NormalSpace.cpp
@@ -62,6 +62,8 @@ NormalSpaceDataPointsFilter<T>::filter(const DataPoints& input)
 template <typename T>
 void NormalSpaceDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 {
+	static const int alreadySampled = -1;
+	
 	//Check number of points
 	const int nbPoints = cloud.getNbPoints();		
 	if(nbSample >= std::size_t(nbPoints))
@@ -115,7 +117,7 @@ void NormalSpaceDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 		bool isEntireBucketSampled = true;
 		for(std::size_t id = 0; id < bucketSize and isEntireBucketSampled; ++id)
 		{
-			isEntireBucketSampled = isEntireBucketSampled and (curBucket[id] == -1);
+			isEntireBucketSampled = isEntireBucketSampled and (curBucket[id] == alreadySampled);
 		}
 
 		if(isEntireBucketSampled)
@@ -129,11 +131,11 @@ void NormalSpaceDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 			 idInBucket = static_cast<std::size_t>(bucketSize * uni01(gen));
 			 idToKeep = curBucket[idInBucket];
 
-		} while(idToKeep == -1); 
+		} while(idToKeep == alreadySampled); 
 
 		keepIndexes.push_back(static_cast<std::size_t>(idToKeep));
 
-		curBucket[idInBucket] = -1; //set sampled flag
+		curBucket[idInBucket] = alreadySampled; //set sampled flag
 	}
 	//TODO: evaluate performances between this solution and sorting the indexes
 	// We build map of (old index to new index), in case we sample pts at the begining of the pointcloud

--- a/pointmatcher/DataPointsFilters/NormalSpace.cpp
+++ b/pointmatcher/DataPointsFilters/NormalSpace.cpp
@@ -1,0 +1,168 @@
+// kate: replace-tabs off; indent-width 4; indent-mode normal
+// vim: ts=4:sw=4:noexpandtab
+/*
+
+Copyright (c) 2010--2018,
+François Pomerleau and Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the authors at <f dot pomerleau at gmail dot com> and
+<stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include "NormalSpace.h"
+
+#include <vector>
+#include <unordered_map>
+#include <random>
+#include <fstream>
+
+// NormalSpaceDataPointsFilter
+template <typename T>
+NormalSpaceDataPointsFilter<T>::NormalSpaceDataPointsFilter(const Parameters& params) :
+	PointMatcher<T>::DataPointsFilter("NormalSpaceDataPointsFilter", 
+		NormalSpaceDataPointsFilter::availableParameters(), params),
+	nbSample{Parametrizable::get<std::size_t>("nbSample")},
+	seed{Parametrizable::get<std::size_t>("seed")},
+	epsilon{Parametrizable::get<T>("epsilon")},
+	nbBucket{std::size_t((2.0*M_PI/epsilon) * (M_PI/epsilon))}
+{
+}
+
+template <typename T>
+typename PointMatcher<T>::DataPoints
+NormalSpaceDataPointsFilter<T>::filter(const DataPoints& input)
+{
+	DataPoints output(input);
+	inPlaceFilter(output);
+	return output;
+}
+
+template <typename T>
+void NormalSpaceDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
+{
+	//Check number of points
+	const int nbPoints = cloud.getNbPoints();		
+	if(nbSample >= std::size_t(nbPoints))
+		return;
+
+	//Check if there is normals info
+	if (!cloud.descriptorExists("normals"))
+		throw InvalidField("OrientNormalsDataPointsFilter: Error, cannot find normals in descriptors.");
+
+	const auto& normals = cloud.getDescriptorViewByName("normals");
+	
+	std::mt19937 gen(seed); //Standard mersenne_twister_engine seeded with seed
+	std::uniform_real_distribution<> uni01(0., 1.);
+	
+	//bucket space
+	std::vector<std::vector<int>> idBuckets; //stock int so we can marked selected with -1
+	idBuckets.resize(nbBucket);
+	
+	std::vector<std::size_t> keepIndexes;
+	keepIndexes.reserve(nbSample);
+	
+	///(1) put all points of the data into buckets based on their normal direction
+	for (int i = 0; i < nbPoints; ++i)
+	{
+		assert(normals.col(i).head(3).norm() == 1);
+		
+		//Theta = polar angle in [0 ; pi]
+		const T theta = std::acos(normals(2, i)); 
+		//Phi = azimuthal angle in [0 ; 2pi] 
+		const T phi = std::atan2(normals(1, i), normals(0, i)) + M_PI;
+		
+		//assert(theta >= 0. and theta =< M_PI and phi >= 0. and phi <= 2.*M_PI);
+		
+		idBuckets[bucketIdx(theta, phi)].push_back(i);
+	}
+	///(2) uniformly pick points from all the buckets until the desired number of points is selected
+	while(keepIndexes.size() < nbSample)
+	{
+		const T theta = std::acos(1 - 2 * uni01(gen));
+        const T phi = 2. * M_PI * uni01(gen);
+		
+        std::vector<int>& curBucket = idBuckets[bucketIdx(theta, phi)];
+        
+        //Check size
+        if(curBucket.empty())
+    		continue;
+    		
+    	const std::size_t bucketSize = curBucket.size();
+    	
+    	//Check if not already all sampled
+    	bool isEntireBucketSampled = true;
+    	for(std::size_t id = 0; id < bucketSize and isEntireBucketSampled; ++id)
+    	{
+    		isEntireBucketSampled = isEntireBucketSampled and (curBucket[id]==-1);
+    	}
+    	
+    	if(isEntireBucketSampled)
+    		continue;
+    	    	
+    	///(3) A point is randomly picked in a bucket that contains multiple points
+    	int idToKeep = 0;
+    	std::size_t idInBucket = 0;
+    	do
+    	{
+    		 idInBucket = static_cast<std::size_t>(bucketSize * uni01(gen));
+    		 idToKeep = curBucket[idInBucket];
+
+    	} while(idToKeep == -1); 
+        
+        keepIndexes.push_back(static_cast<std::size_t>(idToKeep));
+        
+        curBucket[idInBucket] = -1; //set sampled flag
+	}
+	//TODO: evaluate performances between this solution and sorting the indexes
+	// We build map of (old index to new index), in case we sample pts at the begining of the pointcloud
+	std::unordered_map<std::size_t, std::size_t> mapidx;
+	std::size_t idx = 0;
+	
+	///(4) Sample the point cloud
+	for(std::size_t id : keepIndexes)
+	{
+		//retrieve index from lookup table if sampling in already switched element
+		if(id<idx)
+			id = mapidx[id];
+		//Switch columns id and idx
+		cloud.swapCols(idx, id);	
+		//Maintain new index position	
+		mapidx[idx] = id;
+		//Update index
+		++idx;
+	}
+	cloud.conservativeResize(nbSample);
+}
+
+template <typename T>
+std::size_t NormalSpaceDataPointsFilter<T>::bucketIdx(T theta, T phi) const
+{
+	//Theta = polar angle in [0 ; pi] and Phi = azimuthal angle in [0 ; 2pi]
+	return static_cast<std::size_t>(theta / epsilon) * static_cast<std::size_t>(2. * M_PI / epsilon) + static_cast<std::size_t>(phi / epsilon);
+}
+
+template struct NormalSpaceDataPointsFilter<float>;
+template struct NormalSpaceDataPointsFilter<double>;

--- a/pointmatcher/DataPointsFilters/NormalSpace.h
+++ b/pointmatcher/DataPointsFilters/NormalSpace.h
@@ -1,0 +1,93 @@
+// kate: replace-tabs off; indent-width 4; indent-mode normal
+// vim: ts=4:sw=4:noexpandtab
+/*
+
+Copyright (c) 2010--2018,
+François Pomerleau and Stephane Magnenat, ASL, ETHZ, Switzerland
+You can contact the authors at <f dot pomerleau at gmail dot com> and
+<stephane at magnenat dot net>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ETH-ASL BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#pragma once
+
+#include "PointMatcher.h"
+
+template<typename T>
+struct NormalSpaceDataPointsFilter : public PointMatcher<T>::DataPointsFilter
+{
+  	// Type definitions
+	typedef PointMatcher<T> PM;
+	typedef typename PM::DataPoints DataPoints;
+	typedef typename PM::DataPointsFilter DataPointsFilter;
+
+	typedef PointMatcherSupport::Parametrizable Parametrizable;
+	typedef PointMatcherSupport::Parametrizable P;
+	typedef Parametrizable::Parameters Parameters;
+	typedef Parametrizable::ParameterDoc ParameterDoc;
+	typedef Parametrizable::ParametersDoc ParametersDoc;
+	typedef Parametrizable::InvalidParameter InvalidParameter;
+	
+	typedef typename DataPoints::Index Index;
+
+	typedef typename PointMatcher<T>::DataPoints::InvalidField InvalidField;
+
+	inline static const std::string description()
+	{
+		return "Normal Space Sampling (NSS) from S. Rusinkiewicz and M. Levoy, “Efficient Variants of the ICP Algorithm,” in Proceedings Third International Conference on 3-D Digital Imaging and Modeling, 2001, pp. 145–152. Construct a set of buckets in the normal-space, then put all points of the data into buckets based on their normal direction; Finally, uniformly pick points from all the buckets until the desired number of points is selected. **Required** to compute normals as pre-step.";
+	}
+
+	inline static const ParametersDoc availableParameters()
+	{
+		return boost::assign::list_of<ParameterDoc>
+		( "nbSample", "Number of point to select.", "5000", "1", "4294967295", &P::Comp<std::size_t> )
+		( "seed", "Seed for the random generator.", "1", "0", "4294967295", &P::Comp<std::size_t> )
+		( "epsilon", "Step of discretization for the angle spaces", "0.04908738521" /* PI/64 */, "0.00153398078" /* PI/2048 */, "6.28318530718" /* 2PI */, &P::Comp<T> )
+		;
+	}
+
+public:
+	const std::size_t nbSample;
+	const std::size_t seed;
+	const T epsilon;
+	
+	//Ctor, uses parameter interface
+	NormalSpaceDataPointsFilter(const Parameters& params = Parameters());
+	//NormalSpaceDataPointsFilter();
+	
+	//Dtor
+	virtual ~NormalSpaceDataPointsFilter() {};
+
+	virtual DataPoints filter(const DataPoints& input);
+	virtual void inPlaceFilter(DataPoints& cloud);
+
+private:
+	inline std::size_t bucketIdx(T theta, T phi) const;
+	
+	const std::size_t nbBucket;
+};
+	
+

--- a/pointmatcher/DataPointsFilters/NormalSpace.h
+++ b/pointmatcher/DataPointsFilters/NormalSpace.h
@@ -65,7 +65,7 @@ struct NormalSpaceDataPointsFilter : public PointMatcher<T>::DataPointsFilter
 		return boost::assign::list_of<ParameterDoc>
 		( "nbSample", "Number of point to select.", "5000", "1", "4294967295", &P::Comp<std::size_t> )
 		( "seed", "Seed for the random generator.", "1", "0", "4294967295", &P::Comp<std::size_t> )
-		( "epsilon", "Step of discretization for the angle spaces", "0.04908738521" /* PI/64 */, "0.00153398078" /* PI/2048 */, "6.28318530718" /* 2PI */, &P::Comp<T> )
+		( "epsilon", "Step of discretization for the angle spaces", "0.09817477042" /* PI/32 */, "0.04908738521" /* PI/64 */, "3.14159265359" /* PI */, &P::Comp<T> )
 		;
 	}
 

--- a/pointmatcher/DataPointsFiltersImpl.h
+++ b/pointmatcher/DataPointsFiltersImpl.h
@@ -58,6 +58,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "DataPointsFilters/Elipsoids.h"
 #include "DataPointsFilters/Gestalt.h"
 #include "DataPointsFilters/OctreeGrid.h"
+#include "DataPointsFilters/NormalSpace.h"
 
 template<typename T>
 struct DataPointsFiltersImpl
@@ -84,6 +85,7 @@ struct DataPointsFiltersImpl
 	typedef ::ElipsoidsDataPointsFilter<T> ElipsoidsDataPointsFilter;
 	typedef ::GestaltDataPointsFilter<T> GestaltDataPointsFilter;
 	typedef ::OctreeGridDataPointsFilter<T> OctreeGridDataPointsFilter;
+	typedef ::NormalSpaceDataPointsFilter<T> NormalSpaceDataPointsFilter;
 
 }; // DataPointsFiltersImpl
 

--- a/pointmatcher/Registry.cpp
+++ b/pointmatcher/Registry.cpp
@@ -87,6 +87,7 @@ PointMatcher<T>::PointMatcher()
 	ADD_TO_REGISTRAR(DataPointsFilter, ElipsoidsDataPointsFilter, typename DataPointsFiltersImpl<T>::ElipsoidsDataPointsFilter)
 	ADD_TO_REGISTRAR(DataPointsFilter, GestaltDataPointsFilter, typename DataPointsFiltersImpl<T>::GestaltDataPointsFilter)
 	ADD_TO_REGISTRAR(DataPointsFilter, OctreeGridDataPointsFilter, typename DataPointsFiltersImpl<T>::OctreeGridDataPointsFilter)
+	ADD_TO_REGISTRAR(DataPointsFilter, NormalSpaceDataPointsFilter, typename DataPointsFiltersImpl<T>::NormalSpaceDataPointsFilter)
 	
 	ADD_TO_REGISTRAR_NO_PARAM(Matcher, NullMatcher, typename MatchersImpl<T>::NullMatcher)
 	ADD_TO_REGISTRAR(Matcher, KDTreeMatcher, typename MatchersImpl<T>::KDTreeMatcher)

--- a/utest/ui/DataFilters.cpp
+++ b/utest/ui/DataFilters.cpp
@@ -525,16 +525,14 @@ TEST_F(DataFilterTest, NormalSpaceDataPointsFilter)
 			
 			const DP filteredCloud = nssFilter->filter(cloud);
 					
-			if(nbSample == nbPts2D)
+			if(nbSample <= nbPts2D)
 			{
 				validate2dTransformation();
-				
-				EXPECT_EQ(filteredCloud.getNbPoints(), nbPts2D);
+				EXPECT_LE(filteredCloud.getNbPoints(), nbPts2D);
+				continue;
 			}
 			else if (nbSample == nbPts3D)
 			{
-				validate3dTransformation();
-				
 				EXPECT_EQ(filteredCloud.getNbPoints(), nbPts3D);
 			}
 			else if (nbSample == nbPts)
@@ -545,17 +543,10 @@ TEST_F(DataFilterTest, NormalSpaceDataPointsFilter)
 				EXPECT_EQ(cloud.getTimeDim(), filteredCloud.getTimeDim());
 
 				EXPECT_EQ(filteredCloud.getNbPoints(), nbPts);
-			
-				validate2dTransformation();
-				validate3dTransformation();
 			}
-			else
-			{	
-				validate2dTransformation();
-				validate3dTransformation();
-				
-				EXPECT_GE(cloud.getNbPoints(), filteredCloud.getNbPoints());
-			}			
+			
+			validate3dTransformation();			
+			EXPECT_GE(cloud.getNbPoints(), filteredCloud.getNbPoints());
 		}
 }
 

--- a/utest/ui/DataFilters.cpp
+++ b/utest/ui/DataFilters.cpp
@@ -487,6 +487,78 @@ TEST_F(DataFilterTest, OctreeGridDataPointsFilter)
 			}
 }
 
+TEST_F(DataFilterTest, NormalSpaceDataPointsFilter)
+{
+	const size_t nbPts = 60000;
+	DP cloud = generateRandomDataPoints(nbPts);	
+	params = PM::Parameters(); 
+	
+	const size_t nbPts2D = ref2D.getNbPoints();
+	const size_t nbPts3D = ref3D.getNbPoints();
+	
+	PM::DataPointsFilter* nssFilter;
+	
+	//Compute normals
+	auto paramsNorm = PM::Parameters();
+			paramsNorm["knn"] = "5"; 
+			paramsNorm["epsilon"] = "0.1"; 
+			paramsNorm["keepNormals"] = "1";
+	PM::DataPointsFilter*	normalFilter = PM::get().DataPointsFilterRegistrar.create("SurfaceNormalDataPointsFilter", paramsNorm);
+
+	normalFilter->inPlaceFilter(cloud);
+	
+	//Evaluate filter
+	std::vector<size_t> samples = {2*nbPts2D/3, nbPts2D, 1500, 5000, nbPts, nbPts3D};
+	for(const float epsilon : {M_PI/6., M_PI/32., M_PI/64.})
+		for(const size_t nbSample : samples)
+		{
+			icp.readingDataPointsFilters.clear();
+			
+			params.clear();
+			params["epsilon"] = toParam(epsilon);
+			params["nbSample"] = toParam(nbSample);
+
+			nssFilter = PM::get().DataPointsFilterRegistrar.create("NormalSpaceDataPointsFilter", params);
+
+			addFilter("SurfaceNormalDataPointsFilter", paramsNorm);
+			addFilter("NormalSpaceDataPointsFilter", params);
+			
+			const DP filteredCloud = nssFilter->filter(cloud);
+					
+			if(nbSample == nbPts2D)
+			{
+				validate2dTransformation();
+				
+				EXPECT_EQ(filteredCloud.getNbPoints(), nbPts2D);
+			}
+			else if (nbSample == nbPts3D)
+			{
+				validate3dTransformation();
+				
+				EXPECT_EQ(filteredCloud.getNbPoints(), nbPts3D);
+			}
+			else if (nbSample == nbPts)
+			{
+				//Check number of points
+				EXPECT_EQ(cloud.getNbPoints(), filteredCloud.getNbPoints());
+				EXPECT_EQ(cloud.getDescriptorDim(), filteredCloud.getDescriptorDim());
+				EXPECT_EQ(cloud.getTimeDim(), filteredCloud.getTimeDim());
+
+				EXPECT_EQ(filteredCloud.getNbPoints(), nbPts);
+			
+				validate2dTransformation();
+				validate3dTransformation();
+			}
+			else
+			{	
+				validate2dTransformation();
+				validate3dTransformation();
+				
+				EXPECT_GE(cloud.getNbPoints(), filteredCloud.getNbPoints());
+			}			
+		}
+}
+
 TEST_F(DataFilterTest, VoxelGridDataPointsFilter)
 {
 	// Test with point cloud


### PR DESCRIPTION
I added a new filter feature based on Normal Space Sampling (NSS) from _S. Rusinkiewicz and M. Levoy, “Efficient Variants of the ICP Algorithm,” in Proceedings Third International Conference on 3-D Digital Imaging and Modeling, 2001, pp. 145–152_. 

----
The algorithm works as follow:
1. Construct a set of buckets in the normal-space (stocked in a `std::vector`) 
1. Then put all points of the data into buckets based on their normal direction; 
1. Finally, uniformly pick points from all the buckets until the desired number of points is selected.

**Remark:** a point is randomly picked in a bucket that contains multiple points. 
**Remark:** the uniform sampling is based on a standard Mersenne twister engine

---
As the normals are supposed normed, the _n_-space can be represented by polar coordinates, with:
- _theta_, the polar angle in [0 ; pi]
- _phi_, the azimuthal angle in [0 ; 2pi]
- _r_=1, the radius can be omitted

Resources to better understand uniform sampling in normal-space can be found [here](http://corysimon.github.io/articles/uniformdistn-on-sphere/).

---
I had a utest to validate the filter. Some results can be visualized by: 

![nss](https://image.ibb.co/gosJk8/nss.png)
where the left-white point cloud is the normal distribution of the original point cloud,
where the right-red point cloud is the normal distribution of the sampled point cloud

---
I'm open to any suggestion to improve/clean the filter.

BTW, if someone thinks it's better to `sort` the indexes before reinserting the points at the beginning of the point-cloud than to maintain the old indexes in a `map`, I'm interested to discuss it.