### PR TITLE
Quick fix for 2D test case in NormalSpace filter

### DIFF
--- a/doc/Datafilters.md
+++ b/doc/Datafilters.md
@@ -343,6 +343,8 @@ As the normals are supposed normed, the _n_-space can be represented by polar co
 
 Resources to better understand uniform sampling in normal-space can be found [here](http://corysimon.github.io/articles/uniformdistn-on-sphere/).
 
+**Remark:** the current implementation only supports 3D point cloud  
+
 __Required descriptors:__  `normals` (see SurfaceNormalDataPointsFilter)  
 __Output descriptor:__ none  
 __Sensor assumed to be at the origin:__ no  

--- a/pointmatcher/DataPointsFilters/NormalSpace.cpp
+++ b/pointmatcher/DataPointsFilters/NormalSpace.cpp
@@ -59,11 +59,21 @@ NormalSpaceDataPointsFilter<T>::filter(const DataPoints& input)
 	return output;
 }
 
+//TODO: Add support for 2D by building histogram of polar coordinate with uniform sampling
+
 template <typename T>
 void NormalSpaceDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 {
 	static const int alreadySampled = -1;
 	
+	//check dimension
+	const std::size_t featDim = cloud.features.rows();
+	if(featDim < 4) //3D case support only
+	{
+		std::cerr << "ERROR: NormalSpaceDataPointsFilter does not support 2D point cloud yet (does nothing)" << std::endl;
+		return;
+	}
+		
 	//Check number of points
 	const int nbPoints = cloud.getNbPoints();		
 	if(nbSample >= std::size_t(nbPoints))

--- a/utest/ui/DataFilters.cpp
+++ b/utest/ui/DataFilters.cpp
@@ -493,7 +493,7 @@ TEST_F(DataFilterTest, NormalSpaceDataPointsFilter)
 	DP cloud = generateRandomDataPoints(nbPts);	
 	params = PM::Parameters(); 
 	
-	const size_t nbPts2D = ref2D.getNbPoints();
+	//const size_t nbPts2D = ref2D.getNbPoints();
 	const size_t nbPts3D = ref3D.getNbPoints();
 	
 	PM::DataPointsFilter* nssFilter;
@@ -508,7 +508,7 @@ TEST_F(DataFilterTest, NormalSpaceDataPointsFilter)
 	normalFilter->inPlaceFilter(cloud);
 	
 	//Evaluate filter
-	std::vector<size_t> samples = {2*nbPts2D/3, nbPts2D, 1500, 5000, nbPts, nbPts3D};
+	std::vector<size_t> samples = {/* 2*nbPts2D/3, nbPts2D,*/ 1500, 5000, nbPts, nbPts3D};
 	for(const float epsilon : {M_PI/6., M_PI/32., M_PI/64.})
 		for(const size_t nbSample : samples)
 		{
@@ -525,6 +525,7 @@ TEST_F(DataFilterTest, NormalSpaceDataPointsFilter)
 			
 			const DP filteredCloud = nssFilter->filter(cloud);
 					
+			/*
 			if(nbSample <= nbPts2D)
 			{
 				validate2dTransformation();
@@ -535,7 +536,8 @@ TEST_F(DataFilterTest, NormalSpaceDataPointsFilter)
 			{
 				EXPECT_EQ(filteredCloud.getNbPoints(), nbPts3D);
 			}
-			else if (nbSample == nbPts)
+			else */ 
+			if (nbSample == nbPts)
 			{
 				//Check number of points
 				EXPECT_EQ(cloud.getNbPoints(), filteredCloud.getNbPoints());


### PR DESCRIPTION
(fixes #260)

As addressed by #260, the `NormalSpaceDataPointsFilter` trigger an assertion in debug mode due to unsupported 2D point cloud.

Temporary marked the filter as not supporting the 2D case:
- add check for point cloud dimension in filter
- remove 2D test case

**TODO:** add 2D support by building an histogram of 2D normals and uniformly sampling in it. 