### PR TITLE
Added DeprecationWarnings.h to install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,6 +381,7 @@ set_target_properties(pointmatcher PROPERTIES VERSION "${POINTMATCHER_PROJECT_VE
 #========================= Install header ===========================
 
 install(FILES
+	pointmatcher/DeprecationWarnings.h
 	pointmatcher/PointMatcher.h
 	pointmatcher/PointMatcherPrivate.h
 	pointmatcher/Parametrizable.h


### PR DESCRIPTION
Closes #266 

Added missing install in order to fix this error:

```
Errors     << libpointmatcher_ros:make /home/wavelab/catkin_ws/logs/libpointmatcher_ros/build.make.002.log
In file included from /home/wavelab/catkin_ws/src/ethzasl_icp_mapping/libpointmatcher_ros/include/pointmatcher_ros/point_cloud.h:4:0,
                 from /home/wavelab/catkin_ws/src/ethzasl_icp_mapping/libpointmatcher_ros/src/point_cloud.cpp:1:
/usr/local/include/pointmatcher/PointMatcher.h:62:33: fatal error: DeprecationWarnings.h: No such file or directory
compilation terminated.
make[2]: *** [CMakeFiles/pointmatcher_ros.dir/src/point_cloud.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /home/wavelab/catkin_ws/src/ethzasl_icp_mapping/libpointmatcher_ros/include/pointmatcher_ros/transform.h:4:0,
                 from /home/wavelab/catkin_ws/src/ethzasl_icp_mapping/libpointmatcher_ros/src/transform.cpp:1:
/usr/local/include/pointmatcher/PointMatcher.h:62:33: fatal error: DeprecationWarnings.h: No such file or directory
compilation terminated.
make[2]: *** [CMakeFiles/pointmatcher_ros.dir/src/transform.cpp.o] Error 1
make[1]: *** [CMakeFiles/pointmatcher_ros.dir/all] Error 2
make: *** [all] Error 2
cd /home/wavelab/catkin_ws/build/libpointmatcher_ros; catkin build --get-env libpointmatcher_ros | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -

```