### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Extra Reading
 =============
 If you are interested in learning more about different registration algorithms, we recently put together a literature review surveying multiple solutions. The review is organized in the same way as the library and many examples are provided based on real deployments.
 
-F. Pomerleau, F. Colas and R. Siegwart (2015), "_A Review of Point Cloud Registration Algorithms for Mobile Robotics_", __Foundations and Trends® in Robotics__: Vol. 4: No. 1, pp 1-104.  http://dx.doi.org/10.1561/2300000035 
+F. Pomerleau, F. Colas and R. Siegwart (2015), "_A Review of Point Cloud Registration Algorithms for Mobile Robotics_", __Foundations and Trends® in Robotics__: Vol. 4: No. 1, pp 1-104.  https://doi.org/10.1561/2300000035 
 
 If you don't have access to the journal, you can download it from [here](https://www.researchgate.net/publication/277558596_A_Review_of_Point_Cloud_Registration_Algorithms_for_Mobile_Robotics).
 

--- a/doc/ApplicationsAndPub.md
+++ b/doc/ApplicationsAndPub.md
@@ -97,7 +97,7 @@ alt="IMAGE ALT TEXT HERE" width="240" height="180" border="10" /></a>
 
 
 ## Publications using libpointmatcher
-1. F. Pomerleau, F. Colas and R. Siegwart (2015), "A Review of Point Cloud Registration Algorithms for Mobile Robotics", Foundations and Trends® in Robotics: Vol. 4: No. 1, pp 1-104. http://dx.doi.org/10.1561/2300000035 or [Research Gate link](https://www.researchgate.net/publication/277558596_A_Review_of_Point_Cloud_Registration_Algorithms_for_Mobile_Robotics)
+1. F. Pomerleau, F. Colas and R. Siegwart (2015), "A Review of Point Cloud Registration Algorithms for Mobile Robotics", Foundations and Trends® in Robotics: Vol. 4: No. 1, pp 1-104. https://doi.org/10.1561/2300000035 or [Research Gate link](https://www.researchgate.net/publication/277558596_A_Review_of_Point_Cloud_Registration_Algorithms_for_Mobile_Robotics)
 
 1. G. Hitz, F. Pomerleau, F. Colas, and R. Siegwart. "State Estimation for Shore Monitoring Using an Autonomous Surface Vessel." International Symposium on Experimental Robotics (ISER), 2014, 2014.
 

--- a/pointmatcher/Bibliography.cpp
+++ b/pointmatcher/Bibliography.cpp
@@ -178,7 +178,7 @@ namespace PointMatcherSupport
 				{"issn", "0162-8828"},
 				{"pages", "376--380"},
 				{"numpages", "5"},
-				{"url", "http://dx.doi.org/10.1109/34.88573"},
+				{"url", "https://doi.org/10.1109/34.88573"},
 				{"doi", "10.1109/34.88573"},
 				{"acmid", "105525"},
 				{"publisher", "IEEE Computer Society"},
@@ -276,7 +276,7 @@ namespace PointMatcherSupport
 			if (contains(entry, "year"))
 				os << " " << get(entry, "year") << ".";
 			if (contains(entry, "doi"))
-				os << " DOI: [[http://dx.doi.org/" << get(entry, "doi") << "|" << get(entry, "doi") << "]].";
+				os << " DOI: [[https://doi.org/" << get(entry, "doi") << "|" << get(entry, "doi") << "]].";
 			if (contains(entry, "fulltext"))
 				os << " [[" << get(entry, "fulltext") << "|full text]].";
 			os << endl;


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to all static DOI links and any code that generates new DOI links.

Cheers!