### PR TITLE
Fix point2plan error residual

### DIFF
--- a/pointmatcher/ErrorMinimizers/PointToPlane.cpp
+++ b/pointmatcher/ErrorMinimizers/PointToPlane.cpp
@@ -273,7 +273,7 @@ T PointToPlaneErrorMinimizer<T>::computeResidualError(ErrorElements mPts, const 
 
 	for(int i=0; i<normalRef.rows(); i++)
 	{
-		dotProd += (deltas.row(i).array() * normalRef.row(i).array()).matrix();
+		dotProd += (mPts.weights.row(0).array() * deltas.row(i).array().square() * normalRef.row(i).array()).matrix();
 	}
 
 	// return sum of the norm of each dot product

--- a/pointmatcher/ErrorMinimizers/PointToPlane.cpp
+++ b/pointmatcher/ErrorMinimizers/PointToPlane.cpp
@@ -268,17 +268,17 @@ T PointToPlaneErrorMinimizer<T>::computeResidualError(ErrorElements mPts, const 
 
 	const Matrix deltas = mPts.reading.features - mPts.reference.features;
 
-	// dot product of dot = dot(deltas, normals)
+	// dotProd = dot(deltas, normals) = d.n
 	Matrix dotProd = Matrix::Zero(1, normalRef.cols());
-
-	for(int i=0; i<normalRef.rows(); i++)
+	for(int i = 0; i < normalRef.rows(); i++)
 	{
-		dotProd += (mPts.weights.row(0).array() * deltas.row(i).array().square() * normalRef.row(i).array()).matrix();
+		dotProd += (deltas.row(i).array() * normalRef.row(i).array()).matrix();
 	}
+	// residual = w*(d.n)²
+	dotProd = (mPts.weights.row(0).array() * dotProd.array().square()).matrix();
 
 	// return sum of the norm of each dot product
-	Matrix dotProdNorm = dotProd.colwise().norm();
-	return dotProdNorm.sum();
+	return dotProd.sum();
 }
 
 


### PR DESCRIPTION
The old version did not return the correct residual:
![bad](https://latex.codecogs.com/gif.latex?r%20%3D%20%5Csum_k%20e_k%20%5Ccdot%20n_k)
Instead of 
![good](https://latex.codecogs.com/gif.latex?r%20%3D%20%5Csum_k%20w_k%28e_k%20%5Ccdot%20n_k%29%5E2)
where r is the residual, w is the weight, e is the delta between the points and n is the normal.