### PR TITLE
[feature] Add interface to inform if we reached the maximum number of allowed iterations

### DIFF
--- a/pointmatcher/ICP.cpp
+++ b/pointmatcher/ICP.cpp
@@ -64,7 +64,8 @@ InvalidModuleType::InvalidModuleType(const std::string& reason):
 template<typename T>
 PointMatcher<T>::ICPChainBase::ICPChainBase():
 	prefilteredReadingPtsCount(0),
-	prefilteredReferencePtsCount(0)
+	prefilteredReferencePtsCount(0),
+	maxNumIterationsReached(false)
 {}
 
 //! virtual desctructor
@@ -177,6 +178,13 @@ template<typename T>
 unsigned PointMatcher<T>::ICPChainBase::getPrefilteredReferencePtsCount() const
 {
 	return prefilteredReferencePtsCount;
+}
+
+//! Return the flag that informs if we reached the maximum number of iterations during the last iterative process
+template<typename T>
+bool PointMatcher<T>::ICPChainBase::getMaxNumIterationsReached() const
+{
+	return maxNumIterationsReached;
 }
 
 //! Instantiate modules if their names are in the YAML file
@@ -346,6 +354,7 @@ typename PointMatcher<T>::TransformationParameters PointMatcher<T>::ICP::compute
 	TransformationParameters T_iter = Matrix::Identity(dim, dim);
 	
 	bool iterate(true);
+	this->maxNumIterationsReached = false;
 	this->transformationCheckers.init(T_iter, iterate);
 
 	size_t iterationCount(0);
@@ -407,8 +416,15 @@ typename PointMatcher<T>::TransformationParameters PointMatcher<T>::ICP::compute
 		//	stepReading, reference, outlierWeights, matches);
 		
 		// in test
-		
-		this->transformationCheckers.check(T_iter, iterate);
+		try
+		{
+			this->transformationCheckers.check(T_iter, iterate);
+		}
+		catch(const typename TransformationCheckersImpl<T>::CounterTransformationChecker::MaxNumIterationsReached & e)
+		{
+			iterate = false;
+			this->maxNumIterationsReached = true;
+		}
 	
 		++iterationCount;
 	}

--- a/pointmatcher/PointMatcher.h
+++ b/pointmatcher/PointMatcher.h
@@ -661,10 +661,13 @@ struct PointMatcher
 		void loadFromYaml(std::istream& in);
 		unsigned getPrefilteredReadingPtsCount() const;
 		unsigned getPrefilteredReferencePtsCount() const;
+
+		bool getMaxNumIterationsReached() const;
 		
 	protected:
 		unsigned prefilteredReadingPtsCount; //!< remaining number of points after prefiltering but before the iterative process
 		unsigned prefilteredReferencePtsCount; //!< remaining number of points after prefiltering but before the iterative process
+		bool maxNumIterationsReached; //!< store if we reached the maximum number of iterations last time compute was called
 
 		ICPChainBase();
 		

--- a/pointmatcher/TransformationCheckersImpl.cpp
+++ b/pointmatcher/TransformationCheckersImpl.cpp
@@ -69,7 +69,10 @@ void TransformationCheckersImpl<T>::CounterTransformationChecker::check(const Tr
 	//cerr << parameters << endl;
 	
 	if (this->conditionVariables(0) >= this->limits(0))
+	{
 		iterate = false;
+		throw MaxNumIterationsReached();
+	}
 }
 
 template struct TransformationCheckersImpl<float>::CounterTransformationChecker;

--- a/pointmatcher/TransformationCheckersImpl.h
+++ b/pointmatcher/TransformationCheckersImpl.h
@@ -57,6 +57,9 @@ struct TransformationCheckersImpl
 	
 	struct CounterTransformationChecker: public TransformationChecker
 	{
+		//! Struct used to inform through an exeption that ICP reached max number of iterations
+		struct MaxNumIterationsReached {};
+
 		inline static const std::string description()
 		{
 			return "This checker stops the ICP loop after a certain number of iterations.";


### PR DESCRIPTION
Hi,

This is a (very late) followup of #163.

I just came back to use libpointmatcher again and I still need to know if my ICP stopped because it reached the maximum number of allowed iterations or not. Since my previous solution was not accepted, I came about with a simpler one that adds an interface where the user can ask if we reached the limit of iterations. I still use an exception internally to be able to flag the limit being reached, but this is not propagated to the one calling the ICP method. This way we avoid breaking code using libpointmatcher.

I don't think there was any other input about the information users need (neither on #163 nor #23). On my side I just need this info, so I can avoid shipping a modified version of libpointmatcher along with my code. :smile: I would be glad if you could accept it.

Best,
