### PR TITLE
Improve speed of Normal Space filtering

### DIFF
--- a/pointmatcher/DataPointsFilters/NormalSpace.cpp
+++ b/pointmatcher/DataPointsFilters/NormalSpace.cpp
@@ -34,6 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include "NormalSpace.h"
 
+#include <algorithm>
 #include <vector>
 #include <unordered_map>
 #include <random>
@@ -66,8 +67,6 @@ NormalSpaceDataPointsFilter<T>::filter(const DataPoints& input)
 template <typename T>
 void NormalSpaceDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 {
-	static const int alreadySampled = -1;
-	
 	//check dimension
 	const std::size_t featDim = cloud.features.rows();
 	if(featDim < 4) //3D case support only
@@ -88,67 +87,62 @@ void NormalSpaceDataPointsFilter<T>::inPlaceFilter(DataPoints& cloud)
 	const auto& normals = cloud.getDescriptorViewByName("normals");
 	
 	std::mt19937 gen(seed); //Standard mersenne_twister_engine seeded with seed
-	std::uniform_real_distribution<> uni01(0., 1.);
-	
+
 	//bucketed normal space
 	std::vector<std::vector<int> > idBuckets; //stock int so we can marked selected with -1
 	idBuckets.resize(nbBucket);
 	
 	std::vector<std::size_t> keepIndexes;
 	keepIndexes.reserve(nbSample);
-	
+
+	// Generate a random sequence of indices so that elements are placed in buckets in random order
+	std::vector<std::size_t> randIdcs(nbPoints);
+	std::iota(randIdcs.begin(), randIdcs.end(), 0); // 0-nbPoints  TODO is there a way to do this with a generator?
+	std::random_shuffle(randIdcs.begin(), randIdcs.end());
+
 	///(1) put all points of the data into buckets based on their normal direction
-	for (int i = 0; i < nbPoints; ++i)
+	for (auto randIdx : randIdcs)
 	{
-		assert(normals.col(i).head(3).norm() > 0.99999);
-		
+		// Allow for slight approximiation errors
+		assert(normals.col(randIdx).head(3).norm() >= 1.0-0.00001);
+		assert(normals.col(randIdx).head(3).norm() <= 1.0+0.00001);
+		// Catch errors where theta will be NaN
+		assert((normals(2,randIdx) <= 1.0) && (normals(2,randIdx) >= -1.0));
+
 		//Theta = polar angle in [0 ; pi]
-		const T theta = std::acos(normals(2, i)); 
-		//Phi = azimuthal angle in [0 ; 2pi] 
-		const T phi = std::fmod(std::atan2(normals(1, i), normals(0, i)) + 2. * M_PI, 2. * M_PI);
-		
-		//assert(theta >= 0. and theta =< M_PI and phi >= 0. and phi <= 2.*M_PI);
-		
-		idBuckets[bucketIdx(theta, phi)].push_back(i);
+		const T theta = std::acos(normals(2, randIdx));
+		//Phi = azimuthal angle in [0 ; 2pi]
+		const T phi = std::fmod(std::atan2(normals(1, randIdx), normals(0, randIdx)) + 2. * M_PI, 2. * M_PI);
+
+		// Catch normal space hasing errors
+		assert(bucketIdx(theta, phi) < nbBucket);
+		idBuckets[bucketIdx(theta, phi)].push_back(randIdx);
 	}
+
+	// Remove empty buckets
+	idBuckets.erase(std::remove_if(idBuckets.begin(), idBuckets.end(),
+				[](const std::vector<int>& bucket) { return bucket.empty(); }),
+				idBuckets.end());
+
 	///(2) uniformly pick points from all the buckets until the desired number of points is selected
-	while(keepIndexes.size() < nbSample)
+	for (std::size_t i=0; i<nbSample; i++)
 	{
-		const T theta = std::acos(1 - 2 * uni01(gen));
-		const T phi = 2. * M_PI * uni01(gen);
+		// Get a random bucket
+		std::uniform_int_distribution<std::size_t> uniBucket(0,idBuckets.size()-1);
+		std::size_t curBucketIdx = uniBucket(gen);
+		std::vector<int>& curBucket = idBuckets[curBucketIdx];
 
-		std::vector<int>& curBucket = idBuckets[bucketIdx(theta, phi)];
-
-		//Check size
-		if(curBucket.empty())
-			continue;
-	
-		const std::size_t bucketSize = curBucket.size();
-
-		//Check if not already all sampled
-		bool isEntireBucketSampled = true;
-		for(std::size_t id = 0; id < bucketSize and isEntireBucketSampled; ++id)
-		{
-			isEntireBucketSampled = isEntireBucketSampled and (curBucket[id] == alreadySampled);
-		}
-
-		if(isEntireBucketSampled)
-			continue;
-			
 		///(3) A point is randomly picked in a bucket that contains multiple points
-		int idToKeep = 0;
-		std::size_t idInBucket = 0;
-		do
-		{
-			 idInBucket = static_cast<std::size_t>(bucketSize * uni01(gen));
-			 idToKeep = curBucket[idInBucket];
-
-		} while(idToKeep == alreadySampled); 
-
+		int idToKeep = curBucket[curBucket.size()-1];
+		curBucket.pop_back();
 		keepIndexes.push_back(static_cast<std::size_t>(idToKeep));
 
-		curBucket[idInBucket] = alreadySampled; //set sampled flag
+		// Remove the bucket if it is empty
+		if (curBucket.empty()) {
+			idBuckets.erase(idBuckets.begin()+curBucketIdx);
+		}
 	}
+
 	//TODO: evaluate performances between this solution and sorting the indexes
 	// We build map of (old index to new index), in case we sample pts at the begining of the pointcloud
 	std::unordered_map<std::size_t, std::size_t> mapidx;


### PR DESCRIPTION
Improves the speed of Normal Space binning and selection.

Use a more efficient sampling method instead of rejection sampling. Improves runtime speed and determinism by not attempting to sample low probability events. Remove empty bins and randomly select from only the remaining available bins. Points are added into each bin initially in a random order, and are now popped off the back of a list of points inside the bucket.
