### PR TITLE
Fix segfault happening in ICPSequence class

### DIFF
--- a/pointmatcher/ICP.cpp
+++ b/pointmatcher/ICP.cpp
@@ -516,6 +516,28 @@ void PointMatcher<T>::ICPSequence::clearMap()
 	mapPointCloud = DataPoints();
 }
 
+template<typename T>
+void PointMatcher<T>::ICPSequence::setDefault()
+{
+	ICPChainBase::setDefault();
+	
+	if(mapPointCloud.getNbPoints() > 0)
+	{
+		this->matcher->init(mapPointCloud);
+	}
+}
+
+template<typename T>
+void PointMatcher<T>::ICPSequence::loadFromYaml(std::istream& in)
+{
+	ICPChainBase::loadFromYaml(in);
+	
+	if(mapPointCloud.getNbPoints() > 0)
+	{
+		this->matcher->init(mapPointCloud);
+	}
+}
+
 //! Return the map, in global coordinates (slow)
 template<typename T>
 const typename PointMatcher<T>::DataPoints PointMatcher<T>::ICPSequence::getPrefilteredMap() const

--- a/pointmatcher/PointMatcher.h
+++ b/pointmatcher/PointMatcher.h
@@ -658,7 +658,7 @@ struct PointMatcher
 
 		virtual void setDefault();
 		
-		void loadFromYaml(std::istream& in);
+		virtual void loadFromYaml(std::istream& in);
 		unsigned getPrefilteredReadingPtsCount() const;
 		unsigned getPrefilteredReferencePtsCount() const;
 
@@ -733,6 +733,8 @@ struct PointMatcher
 		bool hasMap() const;
 		bool setMap(const DataPoints& map);
 		void clearMap();
+		virtual void setDefault();
+		virtual void loadFromYaml(std::istream& in);
 		PM_DEPRECATED("Use getPrefilteredInternalMap instead. "
 			            "Function now always returns map with filter chain applied. "
 			            "This may have altered your program behavior."


### PR DESCRIPTION
When the functions setDefault or loadFromYaml were called in the middle of a sequence of ICPs, a segfault was happening because the reference KD-tree held by the matcher was destroyed but not reconstructed afterward.