### PR TITLE
Add missing force4DOF param to PointToPlaneWithCov

### DIFF
--- a/pointmatcher/ErrorMinimizers/PointToPlaneWithCov.h
+++ b/pointmatcher/ErrorMinimizers/PointToPlaneWithCov.h
@@ -71,6 +71,7 @@ struct PointToPlaneWithCovErrorMinimizer: public PointToPlaneErrorMinimizer<T>
     {
         return {
             {"force2D", "If set to true(1), the minimization will be force to give a solution in 2D (i.e., on the XY-plane) even with 3D inputs.", "0", "0", "1", &P::Comp<bool>},
+            {"force4DOF", "If set to true(1), the minimization will optimize only yaw and translation, pitch and roll will follow the prior.", "0", "0", "1", &P::Comp<bool>},
             {"sensorStdDev", "sensor standard deviation", "0.01", "0.", "inf", &P::Comp<T>}
         };
     }


### PR DESCRIPTION
#378 added a `force4DOF` param to PointToPlane error minimizer. This param also needs to be added to PointToPlaneWithCov.