### PR TITLE
Reflect new changes in libnabo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ include_directories(SYSTEM "${EIGEN_INCLUDE_DIR}")
 find_package(libnabo REQUIRED PATHS ${LIBNABO_INSTALL_DIR})
 #include(libnaboConfig)
 include_directories(${libnabo_INCLUDE_DIRS})
-set(EXTERNAL_LIBS ${EXTERNAL_LIBS} ${libnabo_LIBRARIES})
+set(EXTERNAL_LIBS ${EXTERNAL_LIBS} libnabo::nabo)
 message(STATUS "libnabo found, version ${libnabo_VERSION} (include=${libnabo_INCLUDE_DIRS} libs=${libnabo_LIBRARIES})")
 
 #--------------------

--- a/libpointmatcherConfig.cmake.in
+++ b/libpointmatcherConfig.cmake.in
@@ -3,6 +3,9 @@
 #  libpointmatcher_INCLUDE_DIRS - include directories for pointmatcher
 #  libpointmatcher_LIBRARIES    - libraries to link against
 
+include(CMakeFindDependencyMacro)
+find_dependency(libnabo REQUIRED)
+
 # Compute paths
 get_filename_component(POINTMATCHER_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 set(libpointmatcher_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")


### PR DESCRIPTION
I got build failures with the latest changes in libnabo. This PR fixes them. Requires https://github.com/ethz-asl/libnabo/pull/106 if building with catkin tools. The change in Config file is needed by downstream packages, e.g. libpointmatcher_ros.