### PR TITLE
Compatibility with libnabo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,10 +144,8 @@ include_directories(SYSTEM "${EIGEN_INCLUDE_DIR}")
 # DEPENDENCY: nabo
 #--------------------
 find_package(libnabo REQUIRED PATHS ${LIBNABO_INSTALL_DIR})
-#include(libnaboConfig)
-include_directories(${libnabo_INCLUDE_DIRS})
-set(EXTERNAL_LIBS ${EXTERNAL_LIBS} ${libnabo_LIBRARIES})
-message(STATUS "libnabo found, version ${libnabo_VERSION} (include=${libnabo_INCLUDE_DIRS} libs=${libnabo_LIBRARIES})")
+set(EXTERNAL_LIBS ${EXTERNAL_LIBS} libnabo::nabo)
+message(STATUS "libnabo found, version ${libnabo_VERSION}")
 
 #--------------------
 # DEPENDENCY: OpenMP (optional)


### PR DESCRIPTION
With the recent CMake change in libnabo (abd2e94), the previous
linking/include directives are incorrect. This change works with libnabo
built from source, and installed via `.deb`.