### PR TITLE
Link against pthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,10 @@ set(EXTERNAL_LIBS "")
 # compile local version of gtest and yaml-cpp
 add_subdirectory(contrib)
 
+#---------------------------
+# DEPENDENCY:  POSIX Threads
+#---------------------------
+set(EXTERNAL_LIBS ${EXTERNAL_LIBS} pthread)
 
 #--------------------
 # DEPENDENCY:  boost


### PR DESCRIPTION
I added [pthread](https://computing.llnl.gov/tutorials/pthreads/) to the list of external libraries that libpointmatcher links against.

This usually fixes pthread linking issues for other packages. Do note that I haven't been able to reproduce this on my PC.

@peci1 @lucaBartolomei You reported linking issues with pthread before, can you verify that this PR solves your issue?