### PR TITLE
Optimized transformations by transposing and then multiplying in place

### DIFF
--- a/pointmatcher/TransformationsImpl.cpp
+++ b/pointmatcher/TransformationsImpl.cpp
@@ -74,7 +74,8 @@ void TransformationsImpl<T>::RigidTransformation::inPlaceCompute(
 		throw TransformationError("RigidTransformation: Error, rotation matrix is not orthogonal.");	
 	
 	// Apply the transformation to features
-	cloud.features.applyOnTheLeft(parameters);
+	// B = A * B translates to B.transpose *= A.transpose()
+	cloud.features.transpose().applyOnTheRight(parameters.transpose());
 
 	// Apply the transformation to descriptors
 	int row(0);
@@ -85,7 +86,8 @@ void TransformationsImpl<T>::RigidTransformation::inPlaceCompute(
 		const std::string& name(cloud.descriptorLabels[i].text);
 		if (name == "normals" || name == "observationDirections")
 		{
-			cloud.descriptors.block(row, 0, span, descCols).applyOnTheLeft(R);
+			// B = A * B translates to B.transpose *= A.transpose()
+			cloud.descriptors.block(row, 0, span, descCols).transpose() *= R.transpose();
 		}
 		
 		row += span;
@@ -188,7 +190,8 @@ void TransformationsImpl<T>::SimilarityTransformation::inPlaceCompute(
 		throw TransformationError("SimilarityTransformation: Error, invalid similarity transform.");
 	
 	// Apply the transformation to features
-	cloud.features.applyOnTheLeft(parameters);
+	// B = A * B translates to B.transpose *= A.transpose()
+	cloud.features.transpose().applyOnTheRight(parameters.transpose());
 	
 	// Apply the transformation to descriptors
 	int row(0);
@@ -199,7 +202,8 @@ void TransformationsImpl<T>::SimilarityTransformation::inPlaceCompute(
 		const std::string& name(cloud.descriptorLabels[i].text);
 		if (name == "normals" || name == "observationDirections")
 		{
-			cloud.descriptors.block(row, 0, span, descCols).applyOnTheLeft(R);
+			// B = A * B translates to B.transpose *= A.transpose()
+			cloud.descriptors.block(row, 0, span, descCols).transpose() *= R.transpose();
 		}
 		
 		row += span;
@@ -243,7 +247,8 @@ void TransformationsImpl<T>::PureTranslation::inPlaceCompute(
 		throw PointMatcherSupport::TransformationError("PureTranslation: Error, left part  not identity.");
 
 	// Apply the transformation to features
-	cloud.features.applyOnTheLeft(parameters);
+	// B = A * B translates to B.transpose *= A.transpose()
+	cloud.features.transpose().applyOnTheRight(parameters.transpose());
 }
 
 template<typename T>


### PR DESCRIPTION
After merging #419 I put some extra time in finding out if we could further optimize the transformation of descriptors.

Based on that I implemented some snippets:

* To benchmark the features transformation: https://godbolt.org/z/ehWfKG

* To benchmark the descriptors rotation: https://godbolt.org/z/vdzPxE

I found out that for matrices like the ones we are processing (MxN, with M sort of small [1,10], but N quite large), it's better to transpose first, and then apply on the left. The Eigen parser seems to faster code when we do this.

![image](https://user-images.githubusercontent.com/7463211/100871337-6ba02080-34a0-11eb-8e2f-591ff690194f.png)

Compared to what we had before:

![image](https://user-images.githubusercontent.com/7463211/100871382-7a86d300-34a0-11eb-897d-c9d71a5a6638.png)

---

My thought on why this happens is that when we transpose we might be loading the matrix in L2/L3 cache (even though we don't enforce Eigen) in-time evaluation, and when the compiler sees applyOnTheRight, it optimizes for an in-place operation on a matrix that is dominantly column-based.


Something curious I found is that with compiler explorer you can try out different compilers, and the code runs just a bit faster with icc.