### PR TITLE
Include iso646.h to add `and`, `or`, `not` macros

### DIFF
--- a/pointmatcher/DataPointsFilters/utils/sparsetv.hpp
+++ b/pointmatcher/DataPointsFilters/utils/sparsetv.hpp
@@ -29,6 +29,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
+
+//Import "and", "or", "not" macros
+#include <iso646.h>
+
 //--ctor
 template <typename T>
 TensorVoting<T>::TensorVoting(T sigma_, std::size_t k_) : sigma{sigma_}, k{k_}


### PR DESCRIPTION
Following the [issue 420](https://github.com/ethz-asl/libpointmatcher/issues/420).