### PR TITLE
Search for pthread or pthreadVC2 lib in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,8 @@ add_subdirectory(contrib)
 #---------------------------
 # DEPENDENCY:  POSIX Threads
 #---------------------------
-set(EXTERNAL_LIBS ${EXTERNAL_LIBS} pthread)
+find_library(pthread_LIB_DIR  NAMES pthread pthreadVC2)
+set(EXTERNAL_LIBS ${EXTERNAL_LIBS} ${pthread_LIB_DIR})
 
 #--------------------
 # DEPENDENCY:  boost


### PR DESCRIPTION
Following [issue 421](https://github.com/ethz-asl/libpointmatcher/issues/421)

pthread is a POSIX library. So Windows can't compile project that include `pthread.h`.
Windows use threads included in `windows.h`.
To use pthread, Windows users have to get [pthreads-win32](https://sourceware.org/pthreads-win32/).
The library provided by pthreads-win32 is called `pthreadVC2.lib`.
So CMake have to search for pthread and pthreadVC2

I'm new to GitHub and CMake, tell me if I'm doing something wrong.