### PR TITLE
Fixes for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,12 @@ add_subdirectory(contrib)
 #---------------------------
 # DEPENDENCY:  POSIX Threads
 #---------------------------
-set(EXTERNAL_LIBS ${EXTERNAL_LIBS} pthread)
+find_package(Threads REQUIRED)
+if (CMAKE_VERSION VERSION_LESS 3.1.0)
+  set(EXTERNAL_LIBS ${EXTERNAL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+else()
+  set(EXTERNAL_LIBS ${EXTERNAL_LIBS} Threads::Threads)
+endif()
 
 #--------------------
 # DEPENDENCY:  boost

--- a/libpointmatcherConfig.cmake.in
+++ b/libpointmatcherConfig.cmake.in
@@ -5,7 +5,10 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(libnabo REQUIRED)
-
+find_package(Boost COMPONENTS thread filesystem system program_options date_time REQUIRED)
+if (Boost_MINOR_VERSION GREATER 47)
+  find_package(Boost COMPONENTS thread filesystem system program_options date_time chrono REQUIRED)
+endif ()
 include(${CMAKE_CURRENT_LIST_DIR}/libpointmatcher-config.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/yaml-cpp-pm-targets.cmake)
 


### PR DESCRIPTION
 - Fixes the pthread dependency as discussed in #428 
 - Fixes the boost dependency declaration in libpointmatcherConfig.cmake.in so the users won't have to declare it in their project.
 
I also have a bug, that says that `yaml-cpp-pm-targets.cmake` cannot be found, and I have to manually copy it from `/build/contrib/yaml-cpp-pm/CMakeFiles/Export/share/libpointmatcher/cmake/` to `./build` but I couldn't find how to fix it. 

Fixes #435 