### PR TITLE
RemoveBeyond option for the maxQuantileDistance filter

### DIFF
--- a/doc/DataFilters.md
+++ b/doc/DataFilters.md
@@ -230,7 +230,7 @@ No example available.
 
 ### Description
 
-Points are filtered according to where they lie on a distribution of their positions along a given axis.  The entire distance range is divided into quantiles which lie between 0 and 1.  One can specify the distance quantile above which points are rejected by the filter.
+Points are filtered according to where they lie on a distribution of their positions along a given axis.  The entire distance range is divided into quantiles which lie between 0 and 1.  One can specify the distance quantile above or beneath which points are rejected by the filter.
 
 __Required descriptors:__ none   
 __Output descriptor:__ none  
@@ -240,15 +240,15 @@ __Impact on the number of points:__ reduces number of points
 |Parameter  |Description  |Default value    |Allowable range|
 |---------  |:---------|:----------------|:--------------|
 |dim        | Dimension over which the distance (from the center) is thresholded | 0 | x:0 y:1 z:2 |
-|ratio |Quantile threshold.  Points whose distance exceed this threshold are rejected by the filter | 0.5 | min: 0.0000001, max: 0.9999999 | 
-
+|ratio |Quantile threshold.  The threshold at which the points are rejected by the filter | 0.5 | min: 0.0000001, max: 0.9999999 | 
+|removeBeyond |If 1 the points beyond the quantile threshold are rejected, else (0) the points under the quantile threshold are rejected | 1 | 1 or 0 | 
 ### Example
 
-In the following example, maximum quantile filtering is performed over the x-axis with a quantile threshold of 0.5.  Therefore, points which have an x-value which exceeds the 50% quantile are rejected.  The output of the filter is displayed in white and overlaid with the input point cloud in the image below.  A sampling region centered at the origin and extending in both directions of the x-axis is clearly visible.
+In the following example, maximum quantile filtering is performed over the x-axis with a quantile threshold of 0.5 and with the option to removeBeyond set to 1.  Therefore, points which have an x-value which exceeds the 50% quantile are removed.  The output of the filter is displayed in white and overlaid with the input point cloud in the image below.  A sampling region centered at the origin and extending in both directions of the x-axis is clearly visible.
 
-|Figure: Maximum quantile on axis filter in the x-direction with a maximum quantile <br>of 0.5.   | Parameters used |
+|Figure: Maximum quantile on axis filter in the x-direction with a maximum quantile <br>of 0.5 and removeBeyond set to 1.   | Parameters used |
 |---|:---|  
-|![max quant after](images/max_quant.png "After applying maximum quantile on axis filter in the x-direction with a maximum quantile of 0.5") | dim : 0 <br> ratio : 0.5 |
+|![max quant after](images/max_quant.png "After applying maximum quantile on axis filter in the x-direction with a maximum quantile of 0.5 and removeByond set to 1") | dim : 0 <br> ratio : 0.5 <br> removeBeyond : 1 |
 
 ## Random Sampling Filter <a name="randomsamplinghead"></a>
 

--- a/pointmatcher/DataPointsFilters/MaxQuantileOnAxis.h
+++ b/pointmatcher/DataPointsFilters/MaxQuantileOnAxis.h
@@ -51,18 +51,20 @@ struct MaxQuantileOnAxisDataPointsFilter: public PointMatcher<T>::DataPointsFilt
 	
 	inline static const std::string description()
 	{
-		return "Subsampling. Filter points beyond a maximum quantile measured on a specific axis.";
+		return "Subsampling. Filter points under or beyond a maximum quantile measured on a specific axis.";
 	}
 	inline static const ParametersDoc availableParameters()
 	{
 		return {
 			{"dim", "dimension on which the filter will be applied. x=0, y=1, z=2", "0", "0", "2", &P::Comp<unsigned>},
-			{"ratio", "maximum quantile authorized. All points beyond that will be filtered.", "0.5", "0.0000001", "0.9999999", &P::Comp<T>}
+			{"ratio", "maximum quantile authorized. All points beyond that will be filtered.", "0.5", "0.0000001", "0.9999999", &P::Comp<T>},
+			{"removeBeyond", "If set to true (1), remove points beyond the quantile ratio; else (0), remove points under the quantile ratio", "1", "0", "1", P::Comp<bool>}
 		};
 	}
 	
 	const unsigned dim;
 	const T ratio;
+	const bool removeBeyond;
 	
 	//! Constructor, uses parameter interface
 	MaxQuantileOnAxisDataPointsFilter(const Parameters& params = Parameters());


### PR DESCRIPTION
This is an option on the maxQuantilePointsFilter to keep the points beyond or **under** the limit. 

![70UnderAndBeyond](https://user-images.githubusercontent.com/69121614/109050664-a385c100-76a7-11eb-9a80-d60e49cdf2dc.JPG)
![70Under](https://user-images.githubusercontent.com/69121614/109050667-a385c100-76a7-11eb-8aed-82a99b732acd.JPG)
![70Beyond](https://user-images.githubusercontent.com/69121614/109050669-a385c100-76a7-11eb-8797-2dd4a6985a63.JPG)


