### PR TITLE
Fix the surface normals datapoints filter covariance matrix bug

### DIFF
--- a/pointmatcher/DataPointsFilters/SamplingSurfaceNormal.cpp
+++ b/pointmatcher/DataPointsFilters/SamplingSurfaceNormal.cpp
@@ -245,7 +245,7 @@ void SamplingSurfaceNormalDataPointsFilter<T>::fuseRange(
 	const Matrix NN = (d.colwise() - mean);
 
 	// compute covariance
-	const Matrix C(NN * NN.transpose());
+	const Matrix C((NN * NN.transpose()) / T(colCount));
 	Vector eigenVa = Vector::Identity(featDim-1, 1);
 	Matrix eigenVe = Matrix::Identity(featDim-1, featDim-1);
 	// Ensure that the matrix is suited for eigenvalues calculation

--- a/pointmatcher/DataPointsFilters/SurfaceNormal.cpp
+++ b/pointmatcher/DataPointsFilters/SurfaceNormal.cpp
@@ -184,7 +184,7 @@ void SurfaceNormalDataPointsFilter<T>::inPlaceFilter(
 		const Vector mean = d.rowwise().sum() / T(realKnn);
 		const Matrix NN = d.colwise() - mean;
 
-		const Matrix C(NN * NN.transpose());
+		const Matrix C((NN * NN.transpose()) / T(realKnn));
 		Vector eigenVa = Vector::Zero(featDim-1, 1);
 		Matrix eigenVe = Matrix::Zero(featDim-1, featDim-1);
 		// Ensure that the matrix is suited for eigenvalues calculation


### PR DESCRIPTION
There was a bug in the computation of the covariance matrix, which had an impact in the eigen values and eigen vectors computation.

In the `SurfaceNormals` filter: the covariance matrix needed to be divided by `realKnn`.
In the `SamplingSurfaceNormals` filter: the covariance matrix needed to be divided by `colCount`.

Credits go to @pomerlef.