### PR TITLE
Change storage ordering of the eigen vectors descriptors

### DIFF
--- a/pointmatcher/DataPointsFilters/utils/utils.h
+++ b/pointmatcher/DataPointsFilters/utils/utils.h
@@ -62,7 +62,7 @@ struct IdxCompare
 
 
 template<typename T>
-std::vector<size_t> 
+std::vector<size_t>
 sortIndexes(const typename PointMatcher<T>::Vector& v)
 {
 	// initialize original index locations
@@ -87,17 +87,15 @@ sortEigenValues(const typename PointMatcher<T>::Vector& eigenVa)
 }
 
 template<typename T>
-typename PointMatcher<T>::Vector 
+typename PointMatcher<T>::Vector
 serializeEigVec(const typename PointMatcher<T>::Matrix& eigenVe)
 {
-	// serialize row major
+	// Serialize the eigen vectors column major
 	const int eigenVeDim = eigenVe.cols();
 	typename PointMatcher<T>::Vector output(eigenVeDim*eigenVeDim);
-	for(int k=0; k < eigenVeDim; ++k)
-	{
-		output.segment(k*eigenVeDim, eigenVeDim) = 
-			eigenVe.row(k).transpose();
-	}
+
+	for (int k = 0; k < eigenVeDim; ++k)
+		output.segment(k * eigenVeDim, eigenVeDim) = eigenVe.col(k);
 
 	return output;
 }


### PR DESCRIPTION
The eigen vectors were serialized row major instead of column major, which shouldn't be the case since everything else is ordered column major in `libpm`. So, it should be assumed that it's also the case for the eigen vectors. This PR will have an impact the users using the following filters:

- [`Ellipsoids (1)`](https://github.com/ethz-asl/libpointmatcher/blob/2ddeb643e8819c137e8e974ff5519a1cdb7014c9/pointmatcher/DataPointsFilters/Elipsoids.cpp#L376), [`Ellipsoids (2)`](https://github.com/ethz-asl/libpointmatcher/blob/2ddeb643e8819c137e8e974ff5519a1cdb7014c9/pointmatcher/DataPointsFilters/Elipsoids.cpp#L379)
- [`Gestalt (1)`](https://github.com/ethz-asl/libpointmatcher/blob/2ddeb643e8819c137e8e974ff5519a1cdb7014c9/pointmatcher/DataPointsFilters/Gestalt.cpp#L536), [`Gestalt (2)`](https://github.com/ethz-asl/libpointmatcher/blob/2ddeb643e8819c137e8e974ff5519a1cdb7014c9/pointmatcher/DataPointsFilters/Gestalt.cpp#L539)
- [`SamplingSurfaceNormal`](https://github.com/ethz-asl/libpointmatcher/blob/2ddeb643e8819c137e8e974ff5519a1cdb7014c9/pointmatcher/DataPointsFilters/SamplingSurfaceNormal.cpp#L279)
- [`SurfaceNormal`](https://github.com/ethz-asl/libpointmatcher/blob/2ddeb643e8819c137e8e974ff5519a1cdb7014c9/pointmatcher/DataPointsFilters/SurfaceNormal.cpp#L240)

and the following descriptors:

- `keepEigenVectors`
- `keepCovariances`

So, retrieving the eigen vectors from a 3D point cloud before this PR could be done like this:

```cpp
PM::Matrix eigenVectors = cloud.getDescriptorsViewByName("eigVectors"); // [ a₁, b₁, c₁, a₂, b₂, c₂, a₃, b₃, c₃ ]ᵀ    

Eigen::Map<PM::Vector, 0, Eigen::InnerStride<3>> a(eigenVectors.col(n).data(), 3);     // [ a₁, a₂, a₃ ]ᵀ
Eigen::Map<PM::Vector, 0, Eigen::InnerStride<3>> b(eigenVectors.col(n).data() + 1, 3); // [ b₁, b₂, b₃ ]ᵀ
Eigen::Map<PM::Vector, 0, Eigen::InnerStride<3>> c(eigenVectors.col(n).data() + 2, 3); // [ c₁, c₂, c₃ ]ᵀ
```

And after this PR it could be done like this:

```cpp
PM::Matrix eigenVectors = cloud.getDescriptorsViewByName("eigVectors"); // [ a₁, a₂, a₃, b₁, b₂, b₃, c₁, c₂, c₃ ]ᵀ    

PM::Vector a = eigenVectors.block(0, n, 3, 1); // [ a₁, a₂, a₃ ]ᵀ
PM::Vector b = eigenVectors.block(3, n, 3, 1); // [ b₁, b₂, b₃ ]ᵀ
PM::Vector c = eigenVectors.block(6, n, 3, 1); // [ c₁, c₂, c₃ ]ᵀ
```

Then, reconstructing the matrix is the same for both method:

```cpp
PM::Matrix R(3,3);
R << a, b, c;
```

As we can see, it is more straightforward to retrieve the eigen vectors when they ordered column major.