### PR TITLE
Histogram<T>::computeStats() without sorting the Histogram

### DIFF
--- a/pointmatcher/Histogram.cpp
+++ b/pointmatcher/Histogram.cpp
@@ -146,14 +146,15 @@ namespace PointMatcherSupport
 			}
 			varV /= T(this->size());
 			// median
-			const Iterator lowQtIt(this->begin() + (this->size() / 4));
-			const Iterator medianIt(this->begin() + (this->size() / 2));
-			const Iterator highQtIt(this->begin() + (3*this->size() / 4));
-			std::nth_element(this->begin(), medianIt, this->end());
+			std::vector<T> hystCpy((*this));
+			const Iterator lowQtIt(hystCpy.begin() + (hystCpy.size() / 4));
+			const Iterator medianIt(hystCpy.begin() + (hystCpy.size() / 2));
+			const Iterator highQtIt(hystCpy.begin() + (3*hystCpy.size() / 4));
+			std::nth_element(hystCpy.begin(), medianIt, hystCpy.end());
 			medianV = *medianIt;
-			std::nth_element(this->begin(), lowQtIt, this->end());
+			std::nth_element(hystCpy.begin(), lowQtIt, hystCpy.end());
 			lowQt = *lowQtIt;
-			std::nth_element(this->begin(), highQtIt, this->end());
+			std::nth_element(hystCpy.begin(), highQtIt, hystCpy.end());
 			highQt = *highQtIt;
 		}
 		else


### PR DESCRIPTION
Currently all values added to a histogram are sorted before being written to a csv file, but I need the values to be written in the order in which they were added.   

## Reason

All histogram value are written in a stream at 
https://github.com/ethz-asl/libpointmatcher/blob/17aa1c10f39c90c896333a5d1750e34da7b43ae8/pointmatcher/Histogram.cpp#L80 
However, `computeStats()` is caled just before and do a `std::nth_element()` on the histogram, so it becomes sorted.

## Solution

I suggest calculating the median, upper and lower quarter on a copy of the histogram, so the original is not sorted.