### PR TITLE
catkin not required for pure cmake packages

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,6 @@
 	<run_depend>boost</run_depend>
 	<run_depend>libnabo</run_depend>
 	<run_depend>eigen</run_depend>
-	<run_depend>catkin</run_depend>
 
 	<export>
 		<build_type>cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
 	<run_depend>boost</run_depend>
 	<run_depend>libnabo</run_depend>
 	<run_depend>eigen</run_depend>
+	<run_depend condition="$ROS_VERSION == 1">catkin</run_depend>
 
 	<export>
 		<build_type>cmake</build_type>


### PR DESCRIPTION
This prevens rosdep resolving in ROS2