### PR TITLE
Fix time values after applying Sampling surface normal filter

### DIFF
--- a/pointmatcher/DataPointsFilters/SamplingSurfaceNormal.cpp
+++ b/pointmatcher/DataPointsFilters/SamplingSurfaceNormal.cpp
@@ -151,6 +151,8 @@ void SamplingSurfaceNormalDataPointsFilter<T>::inPlaceFilter(
 		cloud.features.col(i) = cloud.features.col(k);
 		if (cloud.descriptors.rows() != 0)
 			cloud.descriptors.col(i) = cloud.descriptors.col(k);
+		if (cloud.times.rows() != 0)
+			cloud.times.col(i) = cloud.times.col(k);
 		if(keepNormals)
 			buildData.normals->col(i) = buildData.normals->col(k);
 		if(keepDensities)
@@ -160,9 +162,7 @@ void SamplingSurfaceNormalDataPointsFilter<T>::inPlaceFilter(
 		if(keepEigenVectors)
 			buildData.eigenVectors->col(i) = buildData.eigenVectors->col(k);
 	}
-	cloud.features.conservativeResize(Eigen::NoChange, ptsOut);
-	cloud.descriptors.conservativeResize(Eigen::NoChange, ptsOut);
-
+	cloud.conservativeResize(ptsOut);
 	// warning if some points were dropped
 	if(buildData.unfitPointsCount != 0)
 		LOG_INFO_STREAM("  SamplingSurfaceNormalDataPointsFilter - Could not compute normal for " << buildData.unfitPointsCount << " pts.");


### PR DESCRIPTION
The sampling surface normal filter didn't remove time values corresponding to points removed by the filter. The resulting point cloud thus contained data items of different cardinality and caused a failure when reloaded in libpointmatcher or paraview.