### PR TITLE
Fix omega descriptor export

### DIFF
--- a/pointmatcher/InspectorsImpl.cpp
+++ b/pointmatcher/InspectorsImpl.cpp
@@ -215,6 +215,10 @@ void InspectorsImpl<T>::AbstractVTKInspector::dumpDataPoints(const DataPoints& d
 		{
 			buildTensorStream(stream, "weightSum", data);
 		}
+		else if(it->text == "omega")
+		{
+			buildTensorStream(stream, "omega", data);
+		}
 		else if(it->text == "color")
 		{
 			buildColorStream(stream, "color", data);


### PR DESCRIPTION
The _omega_ descriptor was not listed and, therefore, not exported while saving a compressed point cloud.