### PR TITLE
Add timestamps to save ply

### DIFF
--- a/pointmatcher/IO.cpp
+++ b/pointmatcher/IO.cpp
@@ -1559,12 +1559,29 @@ typename PointMatcherIO<T>::DataPoints PointMatcherIO<T>::loadPLY(std::istream& 
 
 	const unsigned int featDim = featLabelGen.getLabels().totalDim();
 	const unsigned int descDim = descLabelGen.getLabels().totalDim();
-	const unsigned int timeDim = timeLabelGen.getLabels().totalDim();
+	unsigned int timeDim_tmp = timeLabelGen.getLabels().totalDim();
+
+	bool found_sec = false, found_nsec = false, found_time = false;
+	for (const auto& lbl : timeLabelGen.getLabels())
+	{
+	    if (lbl.text == "timestamp_sec")
+	        found_sec = true;
+	    if (lbl.text == "timestamp_nsec")
+	        found_nsec = true;
+	    if (lbl.text == "time")
+	        found_time = true;
+	}
+
+	if (found_sec && found_nsec && !found_time)
+		--timeDim_tmp;
+	const unsigned int& timeDim = timeDim_tmp;
+
+		
 	const unsigned int nbPoints = vertex->num;
 
 	Matrix features = Matrix(featDim, nbPoints);
 	Matrix descriptors = Matrix(descDim, nbPoints);
-	Int64Matrix times = Int64Matrix(timeDim, nbPoints);
+	Int64Matrix times = Int64Matrix::Zero(timeDim, nbPoints);
 
 
 	///////////////////////////
@@ -1674,7 +1691,12 @@ typename PointMatcherIO<T>::DataPoints PointMatcherIO<T>::loadPLY(std::istream& 
 					descriptors(row, col) = value;
 					break;
 				case TIME:
-					times(row, col) = value;
+					if (vertex->properties[propID].name == "timestamp_sec")
+							times(row, col) += value * 1000000000LL;
+					else if (vertex->properties[propID].name == "timestamp_nsec")
+							times(row, col) += value;
+					else
+							times(row, col) = value;
 					break;
 				case UNSUPPORTED:
 					throw runtime_error("Implementation error in loadPLY(). This should not throw.");
@@ -1773,6 +1795,9 @@ void PointMatcherIO<T>::savePLY(const DataPoints& data,
 		}
 	}
 
+	ofs << "property int timestamp_sec" << "\n";
+	ofs << "property int timestamp_nsec" << "\n";
+
 	ofs << "end_header\n";
 
 	// write points
@@ -1814,8 +1839,20 @@ void PointMatcherIO<T>::savePLY(const DataPoints& data,
 			if(d != descRows-1 && !binary)
 				ofs << " ";
 		}
-        if(!binary)
-		    ofs << "\n";
+
+		static_assert(std::is_same<std::decay_t<decltype(data.times(p))>,long>::value,"Type mismatch!");
+		int sec = data.times(p) / 1000000000LL;
+		int nsec = data.times(p) % 1000000000LL;
+		if (binary){
+			ofs.write(reinterpret_cast<const char*>(&sec), sizeof(int));
+			ofs.write(reinterpret_cast<const char*>(&nsec), sizeof(int));
+		}
+		else{
+			ofs << " " << sec;
+			ofs << " " << nsec;
+		}
+		if(!binary)
+			ofs << "\n";
 	}
 
 	ofs.close();

--- a/pointmatcher/IO.h
+++ b/pointmatcher/IO.h
@@ -151,7 +151,9 @@ struct PointMatcherIO
 				{"eigVectors", "eigVectors2Z", DESCRIPTOR},
 				{"intensity", "intensity", DESCRIPTOR},
 				//{"internalName", "externalName", DESCRIPTOR},
-				{"time", "time", TIME}
+				{"time", "time", TIME},
+				{"timestamp_sec", "timestamp_sec", TIME},
+				{"timestamp_nsec", "timestamp_nsec", TIME}
 				//{"internalName", "externalName", TIME}
 			};
 

--- a/utest/ui/IO.cpp
+++ b/utest/ui/IO.cpp
@@ -252,6 +252,50 @@ TEST(IOTest, loadPLY)
 	EXPECT_TRUE(pointCloud.descriptors(1, 1) == 22);
 	EXPECT_TRUE(pointCloud.descriptors(2, 4) == 33);
 
+
+	//test with timestamps
+
+	is.clear();
+	is.str(
+	"ply\n"
+	"format ascii 1.0\n"
+	"element vertex 5\n"
+	"\n" //empty line
+	"property float z\n" // wrong order
+	"property float y\n"
+	"property float x\n"
+	"property float grrrr\n" //unknown property
+	"property float nz\n" // wrong order
+	"property float ny\n"
+	"property float nx\n"
+	"property int timestamp_sec\n"
+	"property int timestamp_nsec\n"
+
+	"end_header\n"
+	"3 2 1 99 33 22 11 42 42000000\n"
+	"3 2 1 99 33 22 11 43 43000000\n"
+	"\n" //empty line
+	"3 2 1 99 33 22 11 44 44000000 3 2 1 99 33 22 11 45 45000000\n" // no line break
+	"3 2 1 99 33 22 11 46 46000000\n"
+
+	);
+	
+	pointCloud = IO::loadPLY(is);
+	
+	// Confirm sizes and dimensions
+	EXPECT_TRUE(pointCloud.features.cols() == 5);
+	EXPECT_TRUE(pointCloud.features.rows() == 4); //x, y, z, pad
+	EXPECT_TRUE(pointCloud.descriptors.cols() == 5);
+	EXPECT_TRUE(pointCloud.descriptors.rows() == 4);//nx, ny, nz, grrrr
+	EXPECT_TRUE(pointCloud.times.cols() == 5);
+	EXPECT_TRUE(pointCloud.times.rows() == 1); // timestamp_sec and timestamp_nsec merged into times
+		
+	// Random value check
+	EXPECT_TRUE(pointCloud.features(0, 0) == 1);
+	EXPECT_TRUE(pointCloud.features(2, 2) == 3);
+	EXPECT_TRUE(pointCloud.descriptors(1, 1) == 22);
+	EXPECT_TRUE(pointCloud.descriptors(2, 4) == 33);
+	EXPECT_TRUE(pointCloud.times(0, 2) == 44 * 1000000000L + 44000000);
 }
 
 


### PR DESCRIPTION
# Description

### Problem

When I run:
```shell
ros2 service call /save_trajectory norlab_icp_mapper_ros/srv/SaveTrajectory "{trajectory_file_name: {data: '$PWD/my_traj.ply'}}"
```

It saves a trajectory, but without timestamps for each point.
Timestamps are passed to libpointmatcher, but the lib doesn't save them in case of `.ply`.
However, I need the timestamps, and I believe this is necessary in many cases.

(I was told lately that exporting to `.vtk` may save the timestamps, but I find working with `.ply` files to be more convenient anyway.)

### Short summary of the solution

Timestamps are passed as int64 to libpointmatcher, but the [PLY standard](https://gamma.cs.unc.edu/POWERPLANT/papers/ply.pdf) does not support int64.  
I therefore had to add two properties int32 to the PLY format: one for seconds and the other for nanoseconds (following the ROS2 convention).

# Main changes

- In `savePLY`, if the data contains times :
  - add two new properties "timestamp_sec" and "timestamp_nsec"
  - split the int64 into two int32 fields
- In `loadPLY`:
  - In phase three  `// 3- RESERVE DATAPOINTS MEMORY` : If "timestamp_sec" (int32) and "timestamp_nsec" (int32) are present, only allocate one int64 field initialized to 0
  - In phase four `// 4- PARSE PLY DATA (vertex)` : If I detect "timestamp_sec" (int32) and "timestamp_nsec" (int32), combine them with the appropriate coefficients into the previously-initialized int64 field.
- Added two new types "TIME" in `IO.h`
- Added a new unit test

# Checklist

- [x] The build passes
- [x] All original unit tests pass
- [x] I added a dedicated unit test for the "timestamps" case
- [x] I tested the branch locally for my use case: trajectory saving with timestamps works perfectly

# Other info

- [Line 80 in norlab_icp_mapper/Trajectory.cpp](https://github.com/norlab-ulaval/norlab_icp_mapper/blob/master/norlab_icp_mapper/Trajectory.cpp) shows that timestamps are passed correctly to libpointmatcher.
- [Line 64 in norlab_icp_mapper/Trajectory.cpp](https://github.com/norlab-ulaval/norlab_icp_mapper/blob/master/norlab_icp_mapper/Trajectory.cpp) shows that times are `int64_t`.
- Tracing the code back, [line 74 in norlab_icp_mapper_ros/mapper_node.cpp](https://github.com/norlab-ulaval/norlab_icp_mapper_ros/blob/ros2/src/mapper_node.cpp) indicates that these times come from `cloudMsgIn.header.stamp`, which based on the [ROS documentation](https://docs.ros.org/en/rolling/p/builtin_interfaces/msg/Time.html) is:
    ```
    int32 sec
    uint32 nanosec
    ```