### PR TITLE
CMake: fix boost system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 #--------------------
 find_package(Boost REQUIRED COMPONENTS thread system program_options date_time)
 if (Boost_MINOR_VERSION GREATER 47)
-	find_package(Boost REQUIRED COMPONENTS thread system program_options date_time chrono)
+	find_package(Boost REQUIRED COMPONENTS thread program_options date_time chrono)
 endif ()
 
 #--------------------


### PR DESCRIPTION
Hi, 

This fix for boost >= 1.89:
```cmake
CMake Error at /nix/store/4qaj1kkf1p3al8z190px12ma6r8jbgqj-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_system"
  (requested version 1.89.0) with any of the following names:

    boost_systemConfig.cmake
    boost_system-config.cmake

  Add the installation prefix of "boost_system" to CMAKE_PREFIX_PATH or set
  "boost_system_DIR" to a directory containing one of the above files.  If
  "boost_system" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  /nix/store/4qaj1kkf1p3al8z190px12ma6r8jbgqj-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake:262 (boost_find_component)
  /nix/store/v2i1hgv567g3v91im5x4g5bff52143i0-cmake-4.1.2/share/cmake-4.1/Modules/FindBoost.cmake:609 (find_package)
  CMakeLists.txt:129 (find_package)
```

boost system has been header only since release 1.69 (December 5, 2018), and a useless stub was provided instead.

in 1.89 (August 6, 2025), that stub was removed, so CMake fail if we require it.

ref. https://www.boost.org/doc/libs/latest/libs/system/doc/html/system.html#changes_in_boost_1_89

# Checklist:

### Code related

- [ ] I have made corresponding changes to the documentation 
      (i.e.: function, class, script header, README.md)
- [ ] I have commented hard-to-understand code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes 
      (Check [contributing_instructions.md](/doc/contributing/contributing_instructions.md) for local testing procedure using _libpointmatcher-build-system_)

### PR creation related

- [x] My pull request `base ref` branch is set to the `develop` branch 
     (the _build-system_ won't be triggered otherwise)
- [x] My pull request branch is up-to-date with the `develop` branch 
     (the _build-system_ will reject it otherwise)

### PR description related

- [x] I have included a quick summary of the changes
- [ ] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`
- [x] I have included a high-level list of changes and their corresponding types
      (See [commit_msg_reference.md](/doc/contributing/commit_msg_reference.md) for details)

---
